### PR TITLE
Use platform-dependent AR

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,6 +29,7 @@ AC_PROG_CC
 AC_PROG_RANLIB
 AC_PROG_CXX
 AM_PROG_CC_C_O
+AM_PROG_AR
 AC_USE_SYSTEM_EXTENSIONS
 m4_ifndef([AM_GNU_GETTEXT],
     [m4_fatal([GNU gettext is required to prepare the Aqualung build])])


### PR DESCRIPTION
Use of platform-prefixed AR tool in case of
```
./configure --build=x86_64-pc-linux-gnu --host=x86_64-pc-linux-gnu
```

Some of distros tries to ensure that packages can be configured to use proper platform-prefixed tools to allow those packages to be build for different host from same system. One of such system is Exherbo linux.