### PR TITLE
Fix build with GCC 10

### DIFF
--- a/src/playlist.c
+++ b/src/playlist.c
@@ -134,8 +134,6 @@ GtkWidget * plist__send_songs_to_iriver;
 GtkWidget * plist__export;
 #endif /* HAVE_TRANSCODING */
 
-gchar command[RB_CONTROL_SIZE];
-
 GtkTreeIter * fileinfo_iter = NULL;
 
 int playlist_dirty;

--- a/src/ports.c
+++ b/src/ports.c
@@ -63,7 +63,7 @@ GtkTreeViewColumn * column_out_R;
 int n_clients;
 GtkListStore * store_out_nb[MAX_JACK_CLIENTS];
 
-gint timeout_tag;
+guint ports_timeout_tag;
 
 int out_selector = 0;
 
@@ -242,7 +242,7 @@ tree_out_L_selection_changed(GtkTreeSelection * selection, gpointer * data) {
 			fprintf(stderr, "ERROR: jack_disconnect() returned %d\n", res);
 		}
 		g_free(str);
-		timeout_tag = aqualung_timeout_add(100, ports_timeout_callback, GINT_TO_POINTER(1));
+		ports_timeout_tag = aqualung_timeout_add(100, ports_timeout_callback, GINT_TO_POINTER(1));
         }
 }
 
@@ -262,7 +262,7 @@ tree_out_R_selection_changed(GtkTreeSelection *selection, gpointer * data) {
 			fprintf(stderr, "ERROR: jack_disconnect() returned %d\n", res);
 		}
 		g_free(str);
-		timeout_tag = aqualung_timeout_add(100, ports_timeout_callback, (gpointer)2);
+		ports_timeout_tag = aqualung_timeout_add(100, ports_timeout_callback, (gpointer)2);
         }
 }
 


### PR DESCRIPTION
In GCC 10, `-fno-common` is the default, so globals with the same name in different files are reported as an error. This fixes two instances of this.

Neither of the `timeout_tag` variables are actually used after assignment at the moment, so an alternative fix would be to remove them too - if you'd prefer this, let me know and I'll update the PR.