### PR TITLE
Use bounded string functions

### DIFF
--- a/src/about.c
+++ b/src/about.c
@@ -444,7 +444,7 @@ create_about_window() {
 	gtk_container_add(GTK_CONTAINER(frame), scrolled_win);
 	gtk_container_add(GTK_CONTAINER(scrolled_win), view);
 
-	sprintf(path, "%s/logo.png", AQUALUNG_DATADIR);
+	arr_snprintf(path, "%s/logo.png", AQUALUNG_DATADIR);
         if ((pixbuf = gdk_pixbuf_new_from_file(path, NULL)) != NULL) {
 		xpm = gtk_image_new_from_pixbuf (pixbuf);
 		gtk_box_pack_start(GTK_BOX(vbox0), xpm, FALSE, FALSE, 0);

--- a/src/build_store.c
+++ b/src/build_store.c
@@ -2337,6 +2337,7 @@ set_prog_action_label(build_store_t * data, char * action) {
 	aqualung_idle_add(set_prog_action_label_idle, data);
 }
 
+/* XXX This function needs reviewing for string bounds checking */
 void
 file_transform(char * buf, file_transform_t * model) {
 

--- a/src/build_store.c
+++ b/src/build_store.c
@@ -488,7 +488,7 @@ capitalize_new() {
 	model->low_enabled = TRUE;
 	model->mode = CAP_ALL_WORDS;
 
-	strncpy(model->pattern, "CD,a),b),c),d),I,II,III,IV,V,VI,VII,VIII,IX,X", MAXLEN-1);
+	arr_strlcpy(model->pattern, "CD,a),b),c),d),I,II,III,IV,V,VI,VII,VIII,IX,X");
 
 	return model;
 }
@@ -650,7 +650,7 @@ capitalize_gui_sync(capitalize_gui_t * gui) {
 	gui->model->low_enabled = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(gui->check_low));
 
 	gui->model->mode = gtk_combo_box_get_active(GTK_COMBO_BOX(gui->combo));
-	strncpy(gui->model->pattern, gtk_entry_get_text(GTK_ENTRY(gui->entry_pre)), MAXLEN-1);
+	arr_strlcpy(gui->model->pattern, gtk_entry_get_text(GTK_ENTRY(gui->entry_pre)));
 
 	gui->model->pre_stringv =
 		g_strsplit(gtk_entry_get_text(GTK_ENTRY(gui->entry_pre)), ",", 0);
@@ -816,8 +816,8 @@ file_transform_gui_sync(file_transform_gui_t * gui) {
 	gui->model->us_to_space = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(gui->check_us_to_space));
 	gui->model->rm_multi_spaces = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(gui->check_rm_multi_spaces));
 
-	strncpy(gui->model->regexp, gtk_entry_get_text(GTK_ENTRY(gui->entry_regexp)), MAXLEN-1);
-	strncpy(gui->model->replacement, gtk_entry_get_text(GTK_ENTRY(gui->entry_replacement)), MAXLEN-1);
+	arr_strlcpy(gui->model->regexp, gtk_entry_get_text(GTK_ENTRY(gui->entry_regexp)));
+	arr_strlcpy(gui->model->replacement, gtk_entry_get_text(GTK_ENTRY(gui->entry_replacement)));
 
 	gtk_widget_hide(gui->label_error);
 
@@ -1531,7 +1531,7 @@ snd_button_test_clicked(GtkWidget * widget, gpointer user_data) {
 	}
 
 	buf[0] = '\0';
-	strncpy(buf, (char *)gtk_entry_get_text(GTK_ENTRY(data->snd_entry_input)), MAXLEN-1);
+	arr_strlcpy(buf, gtk_entry_get_text(GTK_ENTRY(data->snd_entry_input)));
 	file_transform(buf, data->snd_file_trans_gui->model);
 
 	regfree(&data->snd_file_trans_gui->model->compiled);
@@ -2307,7 +2307,7 @@ void
 set_prog_file_entry(build_store_t * data, char * path) {
 
 	AQUALUNG_MUTEX_LOCK(data->mutex);
-	strncpy(data->path, path, MAXLEN-1);
+	arr_strlcpy(data->path, path);
         AQUALUNG_MUTEX_UNLOCK(data->mutex);
 
 	aqualung_idle_add(set_prog_file_entry_idle, data);
@@ -2331,7 +2331,7 @@ void
 set_prog_action_label(build_store_t * data, char * action) {
 
 	AQUALUNG_MUTEX_LOCK(data->mutex);
-	strncpy(data->action, action, MAXLEN-1);
+	arr_strlcpy(data->action, action);
 	AQUALUNG_MUTEX_UNLOCK(data->mutex);
 
 	aqualung_idle_add(set_prog_action_label_idle, data);
@@ -2386,13 +2386,13 @@ file_transform(char * buf, file_transform_t * model) {
 		}
 
 		if (!*tmp) {
-			strncpy(tmp, p + offs, MAXLEN-1);
+			arr_strlcpy(tmp, p + offs);
 		} else {
 			strcat(tmp, p + offs);
 		}
 
 	} else {
-		strncpy(tmp, buf, MAXLEN-1);
+		arr_strlcpy(tmp, buf);
 	}
 
 
@@ -2633,7 +2633,7 @@ process_meta(build_store_t * data, build_disc_t * disc) {
 			}
 
 			if (metadata_get_title(fdec->meta, &tmp) && !is_all_wspace(tmp)) {
-				strncpy(ptrack->name[DATA_SRC_META], tmp, MAXLEN-1);
+				arr_strlcpy(ptrack->name[DATA_SRC_META], tmp);
 			}
 
 			if (disc->record.year[0] == '\0' &&
@@ -2655,7 +2655,7 @@ process_meta(build_store_t * data, build_disc_t * disc) {
 			    metadata_get_comment(fdec->meta, &tmp) &&
 			    !is_all_wspace(tmp)) {
 
-				strncpy(ptrack->comment, tmp, MAXLEN-1);
+				arr_strlcpy(ptrack->comment, tmp);
 			}
 			file_decoder_close(fdec);
 		}
@@ -2663,15 +2663,15 @@ process_meta(build_store_t * data, build_disc_t * disc) {
 	}
 
 	if (map_artist) {
-		strncpy(disc->artist.name[DATA_SRC_META], map_get_max(map_artist), MAXLEN-1);
+		arr_strlcpy(disc->artist.name[DATA_SRC_META], map_get_max(map_artist));
 	}
 
 	if (map_record) {
-		strncpy(disc->record.name[DATA_SRC_META], map_get_max(map_record), MAXLEN-1);
+		arr_strlcpy(disc->record.name[DATA_SRC_META], map_get_max(map_record));
 	}
 
 	if (map_year) {
-		strncpy(disc->record.year, map_get_max(map_year), MAXLEN-1);
+		arr_strlcpy(disc->record.year, map_get_max(map_year));
 	}
 
 	map_free(map_artist);
@@ -2927,7 +2927,7 @@ get_file_list(build_store_t * data, char * dir_record, build_disc_t * disc, int 
 	n = scandir(dir_record, &ent_track, filter, alphasort);
 	for (i = 0; i < n; i++) {
 
-		strncpy(basename, ent_track[i]->d_name, MAXLEN-1);
+		arr_strlcpy(basename, ent_track[i]->d_name);
 		arr_snprintf(filename, "%s/%s", dir_record, ent_track[i]->d_name);
 
 		if (is_dir(filename) || !filter_excl_incl(data, basename)) {
@@ -2943,10 +2943,10 @@ get_file_list(build_store_t * data, char * dir_record, build_disc_t * disc, int 
 				fprintf(stderr, "build_store.c: get_file_list(): calloc error\n");
 				return;
 			} else {
-				strncpy(track->filename, filename, MAXLEN-1);
+				arr_strlcpy(track->filename, filename);
 
 				utf8 = g_filename_display_name(ent_track[i]->d_name);
-				strncpy(track->d_name, utf8, MAXLEN-1);
+				arr_strlcpy(track->d_name, utf8);
 				g_free(utf8);
 
 				track->duration = duration;
@@ -2986,13 +2986,12 @@ process_filename(build_store_t * data, build_disc_t * disc) {
 		if (data->data_src_artist->enabled[i]) {
 
 			if (data->data_src_artist->type[i] == DATA_SRC_FILE) {
-				strncpy(disc->artist.name[DATA_SRC_FILE],
-					disc->artist.d_name, MAXLEN-1);
+				arr_strlcpy(disc->artist.name[DATA_SRC_FILE], disc->artist.d_name);
 			}
 
 			if (disc->artist.name[data->data_src_artist->type[i]][0] != '\0') {
-				strncpy(disc->artist.final,
-					disc->artist.name[data->data_src_artist->type[i]], MAXLEN-1);
+				arr_strlcpy(disc->artist.final,
+					    disc->artist.name[data->data_src_artist->type[i]]);
 				break;
 			}
 		}
@@ -3002,9 +3001,9 @@ process_filename(build_store_t * data, build_disc_t * disc) {
 		if (data->type == BUILD_TYPE_STRICT) {
 			char tmp[MAXLEN];
 			arr_snprintf(tmp, "%s (%s)", _("Unknown Artist"), disc->artist.d_name);
-			strncpy(disc->artist.final, tmp, MAXLEN-1);
+			arr_strlcpy(disc->artist.final, tmp);
 		} else {
-			strncpy(disc->artist.final, _("Unknown Artist"), MAXLEN-1);
+			arr_strlcpy(disc->artist.final, _("Unknown Artist"));
 		}
 		disc->artist.unknown = 1;
 	} else {
@@ -3023,13 +3022,12 @@ process_filename(build_store_t * data, build_disc_t * disc) {
 		if (data->data_src_record->enabled[i]) {
 
 			if (data->data_src_record->type[i] == DATA_SRC_FILE) {
-				strncpy(disc->record.name[DATA_SRC_FILE],
-					disc->record.d_name, MAXLEN-1);
+				arr_strlcpy(disc->record.name[DATA_SRC_FILE], disc->record.d_name);
 			}
 
 			if(disc->record.name[data->data_src_record->type[i]][0] != '\0') {
-				strncpy(disc->record.final,
-					disc->record.name[data->data_src_record->type[i]], MAXLEN-1);
+				arr_strlcpy(disc->record.final,
+					    disc->record.name[data->data_src_record->type[i]]);
 				break;
 			}
 		}
@@ -3039,9 +3037,9 @@ process_filename(build_store_t * data, build_disc_t * disc) {
 		if (data->type == BUILD_TYPE_STRICT) {
 			char tmp[MAXLEN];
 			arr_snprintf(tmp, "%s (%s)", _("Unknown Record"), disc->record.d_name);
-			strncpy(disc->record.final, tmp, MAXLEN-1);
+			arr_strlcpy(disc->record.final, tmp);
 		} else {
-			strncpy(disc->record.final, disc->record.dirname, MAXLEN-1);
+			arr_strlcpy(disc->record.final, disc->record.dirname);
 		}
 		disc->record.unknown = 1;
 	} else {
@@ -3057,27 +3055,26 @@ process_filename(build_store_t * data, build_disc_t * disc) {
 
 	for (i = 0, ptrack = disc->tracks; ptrack; i++, ptrack = ptrack->next) {
 
-		strncpy(ptrack->name[DATA_SRC_FILE], ptrack->d_name, MAXLEN-1);
+		arr_strlcpy(ptrack->name[DATA_SRC_FILE], ptrack->d_name);
 
 		for (j = 0; j < 3; j++) {
 
 			if (data->data_src_track->enabled[j]) {
 
 				if (data->data_src_track->type[i] == DATA_SRC_FILE) {
-					strncpy(ptrack->name[DATA_SRC_FILE],
-						ptrack->d_name, MAXLEN-1);
+					arr_strlcpy(ptrack->name[DATA_SRC_FILE], ptrack->d_name);
 				}
 
 				if (ptrack->name[data->data_src_track->type[j]][0] != '\0') {
-					strncpy(ptrack->final,
-						ptrack->name[data->data_src_track->type[j]], MAXLEN-1);
+					arr_strlcpy(ptrack->final,
+						    ptrack->name[data->data_src_track->type[j]]);
 					break;
 				}
 			}
 		}
 
 		if (j == 3) {
-			strncpy(ptrack->final, ptrack->d_name, MAXLEN-1);
+			arr_strlcpy(ptrack->final, ptrack->d_name);
 		} else {
 			file_transform(ptrack->final, data->file_transform_track);
 
@@ -3092,19 +3089,19 @@ process_filename(build_store_t * data, build_disc_t * disc) {
 
 	switch (data->artist_sort_by) {
 	case SORT_NAME:
-		strncpy(disc->artist.sort, disc->artist.final, MAXLEN-1);
+		arr_strlcpy(disc->artist.sort, disc->artist.final);
 		break;
 	case SORT_NAME_LOW:
 		utf8 = g_utf8_strdown(disc->artist.final, -1);
-		strncpy(disc->artist.sort, utf8, MAXLEN-1);
+		arr_strlcpy(disc->artist.sort, utf8);
 		g_free(utf8);
 		break;
 	case SORT_DIR:
-		strncpy(disc->artist.sort, disc->artist.d_name, MAXLEN-1);
+		arr_strlcpy(disc->artist.sort, disc->artist.d_name);
 		break;
 	case SORT_DIR_LOW:
 		utf8 = g_utf8_strdown(disc->artist.d_name, -1);
-		strncpy(disc->artist.sort, utf8, MAXLEN-1);
+		arr_strlcpy(disc->artist.sort, utf8);
 		g_free(utf8);
 		break;
 	}
@@ -3112,27 +3109,27 @@ process_filename(build_store_t * data, build_disc_t * disc) {
 	if (disc->artist.unknown) {
 		char tmp[MAXLEN];
 		arr_snprintf(tmp, "0 %s", disc->artist.sort);
-		strncpy(disc->artist.sort, tmp, MAXLEN-1);
+		arr_strlcpy(disc->artist.sort, tmp);
 	}
 
 	switch (data->record_sort_by) {
 	case SORT_YEAR:
-		strncpy(disc->record.sort, disc->record.year, MAXLEN-1);
+		arr_strlcpy(disc->record.sort, disc->record.year);
 		break;
 	case SORT_NAME:
-		strncpy(disc->record.sort, disc->record.final, MAXLEN-1);
+		arr_strlcpy(disc->record.sort, disc->record.final);
 		break;
 	case SORT_NAME_LOW:
 		utf8 = g_utf8_strdown(disc->record.final, -1);
-		strncpy(disc->record.sort, utf8, MAXLEN-1);
+		arr_strlcpy(disc->record.sort, utf8);
 		g_free(utf8);
 		break;
 	case SORT_DIR:
-		strncpy(disc->record.sort, disc->record.d_name, MAXLEN-1);
+		arr_strlcpy(disc->record.sort, disc->record.d_name);
 		break;
 	case SORT_DIR_LOW:
 		utf8 = g_utf8_strdown(disc->record.d_name, -1);
-		strncpy(disc->record.sort, utf8, MAXLEN-1);
+		arr_strlcpy(disc->record.sort, utf8);
 		g_free(utf8);
 		break;
 	}
@@ -3140,7 +3137,7 @@ process_filename(build_store_t * data, build_disc_t * disc) {
 	if (disc->record.unknown) {
 		char tmp[MAXLEN];
 		arr_snprintf(tmp, "0 %s", disc->record.sort);
-		strncpy(disc->record.sort, tmp, MAXLEN-1);
+		arr_strlcpy(disc->record.sort, tmp);
 	}
 }
 
@@ -3191,11 +3188,11 @@ process_record(build_store_t * data, char * dir_record, char * artist_d_name, ch
 	}
 
 	utf8 = g_filename_display_name(artist_d_name);
-	strncpy(disc->artist.d_name, utf8, MAXLEN-1);
+	arr_strlcpy(disc->artist.d_name, utf8);
 	g_free(utf8);
 
 	utf8 = g_filename_display_name(record_d_name);
-	strncpy(disc->record.d_name, utf8, MAXLEN-1);
+	arr_strlcpy(disc->record.d_name, utf8);
 	g_free(utf8);
 
 
@@ -3272,11 +3269,11 @@ process_record(build_store_t * data, char * dir_record, char * artist_d_name, ch
 				 &year, tracks, MAXLEN);
 
 		if (artist[0] != '\0') {
-			strncpy(disc->artist.name[DATA_SRC_CDDB], artist, MAXLEN-1);
+			arr_strlcpy(disc->artist.name[DATA_SRC_CDDB], artist);
 		}
 
 		if (record[0] != '\0') {
-			strncpy(disc->record.name[DATA_SRC_CDDB], record, MAXLEN-1);
+			arr_strlcpy(disc->record.name[DATA_SRC_CDDB], record);
 		}
 
 		if (year > 0) {
@@ -3284,7 +3281,7 @@ process_record(build_store_t * data, char * dir_record, char * artist_d_name, ch
 		}
 
 		for (i = 0, ptrack = disc->tracks; ptrack && i < ntracks; i++, ptrack = ptrack->next) {
-			strncpy(ptrack->name[DATA_SRC_CDDB], tracks[i], MAXLEN-1);
+			arr_strlcpy(ptrack->name[DATA_SRC_CDDB], tracks[i]);
 			free(tracks[i]);
 		}
 
@@ -3298,7 +3295,7 @@ process_record(build_store_t * data, char * dir_record, char * artist_d_name, ch
 
 
 	if (data->rec_add_year_to_comment) {
-		strncpy(disc->record.comment, disc->record.year, MAXLEN-1);
+		arr_strlcpy(disc->record.comment, disc->record.year);
 	}
 
 
@@ -3345,16 +3342,16 @@ process_track(build_store_t * data, char * filename, char * d_name, float durati
 		char * utf8;
 
 		utf8 = g_filename_display_name(d_name);
-		strncpy(disc->tracks->d_name, utf8, MAXLEN-1);
-		strncpy(disc->record.d_name, utf8, MAXLEN-1);
-		strncpy(disc->artist.d_name, utf8, MAXLEN-1);
+		arr_strlcpy(disc->tracks->d_name, utf8);
+		arr_strlcpy(disc->record.d_name, utf8);
+		arr_strlcpy(disc->artist.d_name, utf8);
 		g_free(utf8);
 
 		utf8 = g_filename_display_name(filename);
-		strncpy(disc->record.dirname, g_path_get_dirname(utf8), MAXLEN-1);
+		arr_strlcpy(disc->record.dirname, g_path_get_dirname(utf8));
 		g_free(utf8);
 
-		strncpy(disc->tracks->filename, filename, MAXLEN-1);
+		arr_strlcpy(disc->tracks->filename, filename);
 		disc->tracks->duration = duration;
 		disc->tracks->rva = 1.0f;
 		disc->tracks->rva_found = 0;
@@ -3380,7 +3377,7 @@ process_track(build_store_t * data, char * filename, char * d_name, float durati
 
 
 	if (data->rec_add_year_to_comment) {
-		strncpy(disc->record.comment, disc->record.year, MAXLEN-1);
+		arr_strlcpy(disc->record.comment, disc->record.year);
 	}
 
 

--- a/src/build_store.c
+++ b/src/build_store.c
@@ -1512,7 +1512,7 @@ browse_button_clicked(GtkButton * button, gpointer data) {
 				GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
 				FILE_CHOOSER_FILTER_NONE,
 				(GtkWidget *)data,
-				options.currdir);
+				options.currdir, CHAR_ARRAY_SIZE(options.currdir));
 }
 
 

--- a/src/build_store.c
+++ b/src/build_store.c
@@ -2096,8 +2096,8 @@ build_dialog(build_store_t * data) {
 		set_option_from_combo(art_sort_combo, &data->artist_sort_by);
 		set_option_from_combo(rec_sort_combo, &data->record_sort_by);
 
-		set_option_from_entry(gen_entry_excl, data->excl_pattern, MAXLEN);
-		set_option_from_entry(gen_entry_incl, data->incl_pattern, MAXLEN);
+		set_option_from_entry(gen_entry_excl, data->excl_pattern, CHAR_ARRAY_SIZE(data->excl_pattern));
+		set_option_from_entry(gen_entry_incl, data->incl_pattern, CHAR_ARRAY_SIZE(data->incl_pattern));
 
 		set_option_from_toggle(gen_check_excl, &data->excl_enabled);
 		set_option_from_toggle(gen_check_incl, &data->incl_enabled);

--- a/src/build_store.c
+++ b/src/build_store.c
@@ -881,50 +881,50 @@ build_store_new(GtkTreeIter * store_iter, char * file) {
 
 #ifdef HAVE_SNDFILE
 	for (i = 0; valid_extensions_sndfile[i] != NULL; i++) {
-		strcat(data->incl_pattern, "*.");
-		strcat(data->incl_pattern, valid_extensions_sndfile[i]);
-		strcat(data->incl_pattern, ",");
+		arr_strlcat(data->incl_pattern, "*.");
+		arr_strlcat(data->incl_pattern, valid_extensions_sndfile[i]);
+		arr_strlcat(data->incl_pattern, ",");
 	}
 #endif /* HAVE_SNDFILE */
 
 #ifdef HAVE_FLAC
-	strcat(data->incl_pattern, "*.flac,");
+	arr_strlcat(data->incl_pattern, "*.flac,");
 #endif /* HAVE_FLAC */
 
 #ifdef HAVE_VORBIS
-	strcat(data->incl_pattern, "*.ogg,");
+	arr_strlcat(data->incl_pattern, "*.ogg,");
 #endif /* HAVE_VORBIS */
 
 #ifdef HAVE_MPEG
 	for (i = 0; valid_extensions_mpeg[i] != NULL; i++) {
-		strcat(data->incl_pattern, "*.");
-		strcat(data->incl_pattern, valid_extensions_mpeg[i]);
-		strcat(data->incl_pattern, ",");
+		arr_strlcat(data->incl_pattern, "*.");
+		arr_strlcat(data->incl_pattern, valid_extensions_mpeg[i]);
+		arr_strlcat(data->incl_pattern, ",");
 	}
 #endif /* HAVE_MPEG */
 
 #ifdef HAVE_SPEEX
-	strcat(data->incl_pattern, "*.spx,");
+	arr_strlcat(data->incl_pattern, "*.spx,");
 #endif /* HAVE_SPEEX */
 
 #ifdef HAVE_MPC
-	strcat(data->incl_pattern, "*.mpc,");
+	arr_strlcat(data->incl_pattern, "*.mpc,");
 #endif /* HAVE_MPC */
 
 #ifdef HAVE_MAC
-	strcat(data->incl_pattern, "*.ape,");
+	arr_strlcat(data->incl_pattern, "*.ape,");
 #endif /* HAVE_MAC */
 
 #ifdef HAVE_MOD
 	for (i = 0; valid_extensions_mod[i] != NULL; i++) {
-		strcat(data->incl_pattern, "*.");
-		strcat(data->incl_pattern, valid_extensions_mod[i]);
-		strcat(data->incl_pattern, ",");
+		arr_strlcat(data->incl_pattern, "*.");
+		arr_strlcat(data->incl_pattern, valid_extensions_mod[i]);
+		arr_strlcat(data->incl_pattern, ",");
 	}
 #endif /* HAVE_MOD */
 
 #ifdef HAVE_WAVPACK
-	strcat(data->incl_pattern, "*.wv,");
+	arr_strlcat(data->incl_pattern, "*.wv,");
 #endif /* HAVE_WAVPACK */
 
 	if ((pfilter = strrchr(data->incl_pattern, ',')) != NULL) {
@@ -2388,7 +2388,7 @@ file_transform(char * buf, file_transform_t * model) {
 		if (!*tmp) {
 			arr_strlcpy(tmp, p + offs);
 		} else {
-			strcat(tmp, p + offs);
+			arr_strlcat(tmp, p + offs);
 		}
 
 	} else {

--- a/src/build_store.c
+++ b/src/build_store.c
@@ -931,7 +931,7 @@ build_store_new(GtkTreeIter * store_iter, char * file) {
 		*pfilter = '\0';
 	}
 
-	strcpy(data->excl_pattern, "*.jpg,*.jpeg,*.png,*.gif,*.pls,*.m3u,*.cue,*.xml,*.html,*.htm,*.txt,*.ini,*.nfo");
+	arr_strlcpy(data->excl_pattern, "*.jpg,*.jpeg,*.png,*.gif,*.pls,*.m3u,*.cue,*.xml,*.html,*.htm,*.txt,*.ini,*.nfo");
 
 	return data;
 }

--- a/src/build_store.c
+++ b/src/build_store.c
@@ -3267,7 +3267,9 @@ process_record(build_store_t * data, char * dir_record, char * artist_d_name, ch
 			}
 		}
 
-		cddb_query_batch(ntracks, frames, length, artist, record, &year, tracks);
+		cddb_query_batch(ntracks, frames, length,
+				 artist, CHAR_ARRAY_SIZE(artist), record, CHAR_ARRAY_SIZE(record),
+				 &year, tracks, MAXLEN);
 
 		if (artist[0] != '\0') {
 			strncpy(disc->artist.name[DATA_SRC_CDDB], artist, MAXLEN-1);

--- a/src/build_store.c
+++ b/src/build_store.c
@@ -519,7 +519,7 @@ capitalize_load(xmlDocPtr doc, xmlNodePtr node, char * nodeID, capitalize_t ** m
 			xml_load_int(doc, cur, "pre_enabled", &(*model)->pre_enabled);
 			xml_load_int(doc, cur, "low_enabled", &(*model)->low_enabled);
 			xml_load_int(doc, cur, "mode", &(*model)->mode);
-			xml_load_str(doc, cur, "pattern", (*model)->pattern);
+			xml_load_str(doc, cur, "pattern", (*model)->pattern, CHAR_ARRAY_SIZE((*model)->pattern));
 		}
 	}
 }
@@ -703,8 +703,8 @@ file_transform_load(xmlDocPtr doc, xmlNodePtr node, char * nodeID, file_transfor
 
 		for (cur = node->xmlChildrenNode; cur != NULL; cur = cur->next) {
 
-			xml_load_str(doc, cur, "regexp", (*model)->regexp);
-			xml_load_str(doc, cur, "replacement", (*model)->replacement);
+			xml_load_str(doc, cur, "regexp", (*model)->regexp, CHAR_ARRAY_SIZE((*model)->regexp));
+			xml_load_str(doc, cur, "replacement", (*model)->replacement, CHAR_ARRAY_SIZE((*model)->replacement));
 
 			xml_load_int(doc, cur, "rm_number", &(*model)->rm_number);
 			xml_load_int(doc, cur, "rm_extension", &(*model)->rm_extension);
@@ -1020,12 +1020,12 @@ build_store_load(build_store_t * data, int test_only) {
 		for (cur = node->xmlChildrenNode; cur != NULL; cur = cur->next) {
 
 			xml_load_int(doc, cur, "type", &data->type);
-			xml_load_str(doc, cur, "root", data->root);
+			xml_load_str(doc, cur, "root", data->root, CHAR_ARRAY_SIZE(data->root));
 			xml_load_int(doc, cur, "artist_dir_depth", &data->artist_dir_depth);
 			xml_load_int(doc, cur, "excl_enabled", &data->excl_enabled);
-			xml_load_str(doc, cur, "excl_pattern", data->excl_pattern);
+			xml_load_str(doc, cur, "excl_pattern", data->excl_pattern, CHAR_ARRAY_SIZE(data->excl_pattern));
 			xml_load_int(doc, cur, "incl_enabled", &data->incl_enabled);
-			xml_load_str(doc, cur, "incl_pattern", data->incl_pattern);
+			xml_load_str(doc, cur, "incl_pattern", data->incl_pattern, CHAR_ARRAY_SIZE(data->incl_pattern));
 			xml_load_int(doc, cur, "reset_existing_data", &data->reset_existing_data);
 			xml_load_int(doc, cur, "remove_dead_files", &data->remove_dead_files);
 

--- a/src/build_store.c
+++ b/src/build_store.c
@@ -2697,7 +2697,7 @@ add_new_track(GtkTreeIter * record_iter, build_track_t * ptrack, int i) {
 		i = gtk_tree_model_iter_n_children(GTK_TREE_MODEL(music_store), record_iter) + 1;
 	}
 
-	snprintf(sort_name, 15, "%02d", i);
+	arr_snprintf(sort_name, "%02d", i);
 
 	gtk_tree_store_append(music_store, &track_iter, record_iter);
 	gtk_tree_store_set(music_store, &track_iter,
@@ -2928,7 +2928,7 @@ get_file_list(build_store_t * data, char * dir_record, build_disc_t * disc, int 
 	for (i = 0; i < n; i++) {
 
 		strncpy(basename, ent_track[i]->d_name, MAXLEN-1);
-		snprintf(filename, MAXLEN-1, "%s/%s", dir_record, ent_track[i]->d_name);
+		arr_snprintf(filename, "%s/%s", dir_record, ent_track[i]->d_name);
 
 		if (is_dir(filename) || !filter_excl_incl(data, basename)) {
 			free(ent_track[i]);
@@ -3001,7 +3001,7 @@ process_filename(build_store_t * data, build_disc_t * disc) {
 	if (i == 3) {
 		if (data->type == BUILD_TYPE_STRICT) {
 			char tmp[MAXLEN];
-			snprintf(tmp, MAXLEN-1, "%s (%s)", _("Unknown Artist"), disc->artist.d_name);
+			arr_snprintf(tmp, "%s (%s)", _("Unknown Artist"), disc->artist.d_name);
 			strncpy(disc->artist.final, tmp, MAXLEN-1);
 		} else {
 			strncpy(disc->artist.final, _("Unknown Artist"), MAXLEN-1);
@@ -3038,7 +3038,7 @@ process_filename(build_store_t * data, build_disc_t * disc) {
 	if (i == 3) {
 		if (data->type == BUILD_TYPE_STRICT) {
 			char tmp[MAXLEN];
-			snprintf(tmp, MAXLEN-1, "%s (%s)", _("Unknown Record"), disc->record.d_name);
+			arr_snprintf(tmp, "%s (%s)", _("Unknown Record"), disc->record.d_name);
 			strncpy(disc->record.final, tmp, MAXLEN-1);
 		} else {
 			strncpy(disc->record.final, disc->record.dirname, MAXLEN-1);
@@ -3111,7 +3111,7 @@ process_filename(build_store_t * data, build_disc_t * disc) {
 
 	if (disc->artist.unknown) {
 		char tmp[MAXLEN];
-		snprintf(tmp, MAXLEN-1, "0 %s", disc->artist.sort);
+		arr_snprintf(tmp, "0 %s", disc->artist.sort);
 		strncpy(disc->artist.sort, tmp, MAXLEN-1);
 	}
 
@@ -3139,7 +3139,7 @@ process_filename(build_store_t * data, build_disc_t * disc) {
 
 	if (disc->record.unknown) {
 		char tmp[MAXLEN];
-		snprintf(tmp, MAXLEN-1, "0 %s", disc->record.sort);
+		arr_snprintf(tmp, "0 %s", disc->record.sort);
 		strncpy(disc->record.sort, tmp, MAXLEN-1);
 	}
 }
@@ -3278,7 +3278,7 @@ process_record(build_store_t * data, char * dir_record, char * artist_d_name, ch
 		}
 
 		if (year > 0) {
-			snprintf(disc->record.year, MAXLEN-1, "%d", year);
+			arr_snprintf(disc->record.year, "%d", year);
 		}
 
 		for (i = 0, ptrack = disc->tracks; ptrack && i < ntracks; i++, ptrack = ptrack->next) {
@@ -3418,7 +3418,7 @@ scan_artist_record(build_store_t * data, char * dir_artist, char * name_artist, 
 			break;
 		}
 
-		snprintf(dir_record, MAXLEN-1, "%s/%s", dir_artist, ent_record[i]->d_name);
+		arr_snprintf(dir_record, "%s/%s", dir_artist, ent_record[i]->d_name);
 
 		if (!is_dir(dir_record)) {
 			free(ent_record[i]);
@@ -3485,7 +3485,7 @@ scan_recursively(build_store_t * data, char * dir) {
 			break;
 		}
 
-		snprintf(path, MAXLEN-1, "%s/%s", dir, ent[i]->d_name);
+		arr_snprintf(path, "%s/%s", dir, ent[i]->d_name);
 
 		if (is_dir(path)) {
 			scan_recursively(data, path);

--- a/src/build_store.c
+++ b/src/build_store.c
@@ -2078,7 +2078,7 @@ build_dialog(build_store_t * data) {
 			goto display;
 		}
 
-		normalize_filename(proot, data->root);
+		normalize_filename(proot, data->root, CHAR_ARRAY_SIZE(data->root));
 		g_free(proot);
 
 

--- a/src/cd_ripper.c
+++ b/src/cd_ripper.c
@@ -865,7 +865,7 @@ cd_ripper_dialog(cdda_drive_t * drive, GtkTreeIter * iter) {
                         goto ripper_display;
                 }
 
-		normalize_filename(pdestdir, destdir);
+		normalize_filename(pdestdir, destdir, CHAR_ARRAY_SIZE(destdir));
 		g_free(pdestdir);
 
 		if (access(destdir, R_OK | W_OK) != 0) {

--- a/src/cd_ripper.c
+++ b/src/cd_ripper.c
@@ -888,9 +888,9 @@ cd_ripper_dialog(cdda_drive_t * drive, GtkTreeIter * iter) {
 		options.cdrip_vbr = ripper_vbr;
 		set_option_from_toggle(ripper_meta_check, &ripper_meta);
 		options.cdrip_metadata = ripper_meta;
-		set_option_from_entry(ripper_artist_entry, ripper_artist, MAXLEN);
-		set_option_from_entry(ripper_album_entry, ripper_album, MAXLEN);
-		set_option_from_entry(ripper_genre_entry, ripper_genre, MAXLEN);
+		set_option_from_entry(ripper_artist_entry, ripper_artist, CHAR_ARRAY_SIZE(ripper_artist));
+		set_option_from_entry(ripper_album_entry, ripper_album, CHAR_ARRAY_SIZE(ripper_album));
+		set_option_from_entry(ripper_genre_entry, ripper_genre, CHAR_ARRAY_SIZE(ripper_genre));
 		set_option_from_spin(ripper_year_spinner, &ripper_year);
 		ripper_write_to_store = get_ripper_deststore_iter(&ripper_dest_store);
 

--- a/src/cd_ripper.c
+++ b/src/cd_ripper.c
@@ -243,7 +243,7 @@ ripper_destdir_browse_cb(GtkButton * button, gpointer data) {
 				GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
 				FILE_CHOOSER_FILTER_NONE,
 				(GtkWidget *)data,
-				options.ripdir);
+				options.ripdir, CHAR_ARRAY_SIZE(options.ripdir));
 }
 
 

--- a/src/cd_ripper.c
+++ b/src/cd_ripper.c
@@ -182,7 +182,7 @@ ripper_source_write_back(GtkTreeIter * record_iter, char * artist, char * record
 	strncpy(disc->genre, genre, MAXLEN-1);
 	disc->year = year;
 
-	snprintf(tmp, MAXLEN-1, "%s: %s", artist, record);
+	arr_snprintf(tmp, "%s: %s", artist, record);
 	gtk_tree_store_set(music_store, record_iter, MS_COL_NAME, tmp, -1);
 	
 
@@ -398,11 +398,11 @@ ripper_bitrate_changed(GtkRange * range, gpointer data) {
 		switch (i) {
 		case 0:
 		case 8:
-			snprintf(str, 255, "%d (%s)", i, (i == 0) ? _("fast") : _("best"));
+			arr_snprintf(str, "%d (%s)", i, (i == 0) ? _("fast") : _("best"));
 			gtk_label_set_text(GTK_LABEL(ripper_bitrate_value_label), str);
 			break;
 		default:
-			snprintf(str, 255, "%d", i);
+			arr_snprintf(str, "%d", i);
 			gtk_label_set_text(GTK_LABEL(ripper_bitrate_value_label), str);
 			break;
 		}
@@ -410,7 +410,7 @@ ripper_bitrate_changed(GtkRange * range, gpointer data) {
 	if (strcmp(text, "Ogg Vorbis") == 0) {
 		int i = (int)val;
 		char str[256];
-		snprintf(str, 255, "%d", i);
+		arr_snprintf(str, "%d", i);
 		gtk_label_set_text(GTK_LABEL(ripper_bitrate_value_label), str);
 	}
 	if (strcmp(text, "MP3") == 0) {
@@ -419,7 +419,7 @@ ripper_bitrate_changed(GtkRange * range, gpointer data) {
 #ifdef HAVE_LAME
 		i = lame_encoder_validate_bitrate(i, 0);
 #endif /* HAVE_LAME */
-		snprintf(str, 255, "%d", i);
+		arr_snprintf(str, "%d", i);
 		gtk_label_set_text(GTK_LABEL(ripper_bitrate_value_label), str);
 	}
 	g_free(text);
@@ -570,7 +570,7 @@ ripper_make_dest_iters(GtkTreeIter * store_iter,
 		}
 
 		record_data->year = ripper_year;
-		snprintf(str_year, 15, "%d", ripper_year);
+		arr_snprintf(str_year, "%d", ripper_year);
 
                 gtk_tree_store_append(music_store, record_iter, artist_iter);
                 gtk_tree_store_set(music_store, record_iter,
@@ -609,7 +609,7 @@ ripper_make_dest_iters(GtkTreeIter * store_iter,
         }
 
 	record_data->year = ripper_year;
-	snprintf(str_year, 15, "%d", ripper_year);
+	arr_snprintf(str_year, "%d", ripper_year);
 
         gtk_tree_store_append(music_store, record_iter, artist_iter);
         gtk_tree_store_set(music_store, record_iter,
@@ -1117,7 +1117,7 @@ ripper_update_status(gpointer pdata) {
 	if (!ripper_prog_window_visible) {
 		char title[MAXLEN];
 
-		snprintf(title, MAXLEN, "%d%% - %s", prog_total, _("Ripping CD tracks"));
+		arr_snprintf(title, "%d%% - %s", prog_total, _("Ripping CD tracks"));
 		gtk_window_set_title(GTK_WINDOW(ripper_prog_window), title);
 	}
 
@@ -1227,8 +1227,8 @@ ripper_thread(void * arg) {
 			break;
 		}
 
-		snprintf(decoder_filename, 255, "CDDA %s %lX %d", drive->device_path, hash, no);
-		snprintf(mode.filename, MAXLEN-1, "%s/track%02d.%s", destdir, no, ext);
+		arr_snprintf(decoder_filename, "CDDA %s %lX %d", drive->device_path, hash, no);
+		arr_snprintf(mode.filename, "%s/track%02d.%s", destdir, no, ext);
 		mode.file_lib = ripper_format;
 		mode.sample_rate = 44100;
 		mode.channels = 2;
@@ -1244,7 +1244,7 @@ ripper_thread(void * arg) {
 		if (mode.write_meta) {
 			mode.meta = metadata_new();
 			char date[8];
-			snprintf(date, 7, "%d", ripper_year);
+			arr_snprintf(date, "%d", ripper_year);
 
 			ripper_meta_add(mode.meta, tags, META_FIELD_ARTIST, ripper_artist, 0);
 			ripper_meta_add(mode.meta, tags, META_FIELD_ALBUM, ripper_album, 0);
@@ -1307,7 +1307,7 @@ ripper_thread(void * arg) {
 			track_data->duration = track_sectors_read / 75.0;
 			track_data->volume = 1.0f;
 
-			snprintf(sort_name, 3, "%02d", no);
+			arr_snprintf(sort_name, "%02d", no);
 
 			gtk_tree_store_append(music_store, &iter, &ripper_dest_record);
 			gtk_tree_store_set(music_store, &iter,

--- a/src/cd_ripper.c
+++ b/src/cd_ripper.c
@@ -921,7 +921,7 @@ cd_ripper_dialog(cdda_drive_t * drive, GtkTreeIter * iter) {
 
 
 void
-sector_to_str(int sector, char * str) {
+sector_to_str(int sector, char * str, size_t str_len) {
 
 	int m, s, f;
 
@@ -929,7 +929,7 @@ sector_to_str(int sector, char * str) {
 	s = sector / 75 - m * 60;
 	f = sector % 75;
 
-	snprintf(str, MAXLEN-1, "%d [%02d:%02d.%02d]", sector, m, s, f);
+	snprintf(str, str_len, "%d [%02d:%02d.%02d]", sector, m, s, f);
 }
 
 
@@ -956,8 +956,8 @@ ripper_prog_store_make(cdda_drive_t * drive) {
 
 		len = drive->disc.toc[n] - drive->disc.toc[n-1];
 		total_sectors += len;
-		sector_to_str(drive->disc.toc[n-1], begin);
-		sector_to_str(len, length);
+		sector_to_str(drive->disc.toc[n-1], begin, CHAR_ARRAY_SIZE(begin));
+		sector_to_str(len, length, CHAR_ARRAY_SIZE(length));
 		sprintf(num, "%d.", n);
 
 		gtk_list_store_append(ripper_prog_store, &iter);
@@ -969,7 +969,7 @@ ripper_prog_store_make(cdda_drive_t * drive) {
 				   -1);
 	}
 
-	sector_to_str(total_sectors, length);
+	sector_to_str(total_sectors, length, CHAR_ARRAY_SIZE(length));
 	
 	gtk_list_store_append(ripper_prog_store, &iter);
 	gtk_list_store_set(ripper_prog_store, &iter,

--- a/src/cd_ripper.c
+++ b/src/cd_ripper.c
@@ -958,7 +958,7 @@ ripper_prog_store_make(cdda_drive_t * drive) {
 		total_sectors += len;
 		sector_to_str(drive->disc.toc[n-1], begin, CHAR_ARRAY_SIZE(begin));
 		sector_to_str(len, length, CHAR_ARRAY_SIZE(length));
-		sprintf(num, "%d.", n);
+		arr_snprintf(num, "%d.", n);
 
 		gtk_list_store_append(ripper_prog_store, &iter);
 		gtk_list_store_set(ripper_prog_store, &iter,

--- a/src/cd_ripper.c
+++ b/src/cd_ripper.c
@@ -177,9 +177,9 @@ ripper_source_write_back(GtkTreeIter * record_iter, char * artist, char * record
 	gtk_tree_model_get(GTK_TREE_MODEL(music_store), record_iter, MS_COL_DATA, &drive, -1);
 	disc = &drive->disc;
 
-	strncpy(disc->artist_name, artist, MAXLEN-1);
-	strncpy(disc->record_name, record, MAXLEN-1);
-	strncpy(disc->genre, genre, MAXLEN-1);
+	arr_strlcpy(disc->artist_name, artist);
+	arr_strlcpy(disc->record_name, record);
+	arr_strlcpy(disc->genre, genre);
 	disc->year = year;
 
 	arr_snprintf(tmp, "%s: %s", artist, record);
@@ -881,7 +881,7 @@ cd_ripper_dialog(cdda_drive_t * drive, GtkTreeIter * iter) {
 			goto ripper_display;
 		}
 
-		strncpy(options.ripdir, destdir, MAXLEN-1);
+		arr_strlcpy(options.ripdir, destdir);
 		options.cdrip_file_format = ripper_format = get_ripper_format();
 		options.cdrip_bitrate = ripper_bitrate = gtk_range_get_value(GTK_RANGE(ripper_bitrate_scale));
 		set_option_from_toggle(ripper_vbr_check, &ripper_vbr);

--- a/src/cdda.c
+++ b/src/cdda.c
@@ -313,7 +313,7 @@ cdda_scan_drive(char * device_path, cdda_drive_t * cdda_drive) {
 		if (!cdda_drive->cdio) {
 			return -1;
 		}		
-		strncpy(cdda_drive->device_path, device_path, CDDA_MAXLEN-1);
+		arr_strlcpy(cdda_drive->device_path, device_path);
 	}
 	
 	cdda_drive->disc.n_tracks = 0;
@@ -368,8 +368,8 @@ cdda_scan_drive(char * device_path, cdda_drive_t * cdda_drive) {
 	cdda_drive->disc.hash = calc_cdda_hash(&cdda_drive->disc);
 
 	if (cdda_drive->disc.hash != cdda_drive->disc.hash_prev) {
-		strncpy(cdda_drive->disc.artist_name, _("Unknown Artist"), MAXLEN-1);
-		strncpy(cdda_drive->disc.record_name, _("Unknown Record"), MAXLEN-1);
+		arr_strlcpy(cdda_drive->disc.artist_name, _("Unknown Artist"));
+		arr_strlcpy(cdda_drive->disc.record_name, _("Unknown Record"));
 
 		cdda_drive->swap_bytes = -1; /* unknown */
 	}
@@ -620,14 +620,14 @@ update_track_data_from_cdtext(cdda_drive_t * drive, GtkTreeIter * iter_drive) {
 
 		performer = cdda_get_cdtext(cdio, CDTEXT_FIELD_PERFORMER, i);
 		if (performer && *performer != '\0') {
-			g_strlcpy(drive->disc.artist_name, performer, MAXLEN);
+			arr_strlcpy(drive->disc.artist_name, performer);
 		} else {
 			ret = 1;
 		}
 
 		title = cdda_get_cdtext(cdio, CDTEXT_FIELD_TITLE, i);
 		if (title && *title != '\0') {
-			g_strlcpy(drive->disc.record_name, title, MAXLEN);
+			arr_strlcpy(drive->disc.record_name, title);
 		} else {
 			ret = 1;
 		}

--- a/src/cdda.c
+++ b/src/cdda.c
@@ -200,7 +200,7 @@ symlink_deref_absolute(char * symlink, char * path) {
 	if (!g_path_is_absolute(path)) {
 		char tmp[CDDA_MAXLEN];
 		char * dir = g_path_get_dirname(symlink);
-		snprintf(tmp, CDDA_MAXLEN-1, "%s/%s", dir, path);
+		arr_snprintf(tmp, "%s/%s", dir, path);
 		strcpy(path, tmp);
 		g_free(dir);
 	}
@@ -674,9 +674,9 @@ update_track_data(cdda_drive_t * drive, GtkTreeIter iter_drive) {
 
 		cdda_track_t * data;
 
-		snprintf(title, MAXLEN-1, "Track %d", i+1);
-		snprintf(path, CDDA_MAXLEN-1, "CDDA %s %lX %d", drive->device_path, drive->disc.hash, i+1);
-		snprintf(sort, 15, "%02d", i+1);
+		arr_snprintf(title, "Track %d", i+1);
+		arr_snprintf(path, "CDDA %s %lX %d", drive->device_path, drive->disc.hash, i+1);
+		arr_snprintf(sort, "%02d", i+1);
 
 		if ((data = (cdda_track_t *)malloc(sizeof(cdda_track_t))) == NULL) {
 			fprintf(stderr, "update_track_data: malloc error\n");
@@ -725,14 +725,14 @@ insert_cdda_drive_node(char * device_path) {
 	}
 
 	if (drive->disc.n_tracks > 0) {
-		snprintf(str_title, MAXLEN-1, "%s [%s]",
-			 _("Unknown disc"), cdda_displayed_device_path(device_path));
+		arr_snprintf(str_title, "%s [%s]",
+			     _("Unknown disc"), cdda_displayed_device_path(device_path));
 	} else {
-		snprintf(str_title, MAXLEN-1, "%s [%s]",
-			 _("No disc"), cdda_displayed_device_path(device_path));
+		arr_snprintf(str_title, "%s [%s]",
+			     _("No disc"), cdda_displayed_device_path(device_path));
 	}
 
-	snprintf(str_sort, 15, "%d", cdda_get_n(device_path));
+	arr_snprintf(str_sort, "%d", cdda_get_n(device_path));
 
 	gtk_tree_model_get_iter_first(GTK_TREE_MODEL(music_store), &iter_cdda);
 
@@ -810,11 +810,11 @@ refresh_cdda_drive_node(char * device_path) {
 	}
 
 	if (drive->disc.n_tracks > 0) {
-		snprintf(str_title, MAXLEN-1, "%s [%s]", _("Unknown disc"),
-			 cdda_displayed_device_path(device_path));
+		arr_snprintf(str_title, "%s [%s]", _("Unknown disc"),
+			     cdda_displayed_device_path(device_path));
 	} else {
-		snprintf(str_title, MAXLEN-1, "%s [%s]", _("No disc"),
-			 cdda_displayed_device_path(device_path));
+		arr_snprintf(str_title, "%s [%s]", _("No disc"),
+			     cdda_displayed_device_path(device_path));
 	}
 
 	gtk_tree_store_set(music_store, &iter_drive, MS_COL_NAME, str_title, -1);

--- a/src/cddb_lookup.c
+++ b/src/cddb_lookup.c
@@ -377,7 +377,8 @@ store_cdda_export_merged(cddb_lookup_t * data, char * artist, char * record, cha
 
 
 void
-cddb_lookup_merge(cddb_lookup_t * data, char * artist, char * record, char * genre, int * year, char ** tracks) {
+cddb_lookup_merge(cddb_lookup_t * data, char * artist, size_t artist_size, char * record, size_t record_size,
+		  char * genre, size_t genre_size, int * year, char ** tracks, size_t track_size) {
 
 	int i, j, y;
 
@@ -431,15 +432,15 @@ cddb_lookup_merge(cddb_lookup_t * data, char * artist, char * record, char * gen
 	}
 
 	if (map_artist) {
-		strncpy(artist, map_get_max(map_artist), MAXLEN-1);
+		g_strlcpy(artist, map_get_max(map_artist), artist_size);
 	}
 
 	if (map_record) {
-		strncpy(record, map_get_max(map_record), MAXLEN-1);
+		g_strlcpy(record, map_get_max(map_record), record_size);
 	}
 
 	if (map_genre) {
-		strncpy(genre, map_get_max(map_genre), MAXLEN-1);
+		g_strlcpy(genre, map_get_max(map_genre), genre_size);
 	}
 
 	if (map_year) {
@@ -449,7 +450,7 @@ cddb_lookup_merge(cddb_lookup_t * data, char * artist, char * record, char * gen
 	for (j = 0; j < data->ntracks; j++) {
 
 		if (map_tracks[j]) {
-			strncpy(tracks[j], map_get_max(map_tracks[j]), MAXLEN-1);
+			g_strlcpy(tracks[j], map_get_max(map_tracks[j]), track_size);
 			map_free(map_tracks[j]);
 		}
 	}
@@ -546,7 +547,8 @@ cdda_auto_query_timeout_cb(gpointer user_data) {
 			}
 		}
 
-		cddb_lookup_merge(data, artist, record, genre, &year, tracks);
+		cddb_lookup_merge(data, artist, CHAR_ARRAY_SIZE(artist), record, CHAR_ARRAY_SIZE(record),
+				  genre, CHAR_ARRAY_SIZE(genre), &year, tracks, MAXLEN);
 		store_cdda_export_merged(data, artist, record, genre, year, tracks);
 
 		for (i = 0; i < data->ntracks; i++) {
@@ -1172,7 +1174,8 @@ cddb_auto_query_cdda(GtkTreeIter * drive_iter, int ntracks, int * frames, int le
 
 void
 cddb_query_batch(int ntracks, int * frames, int length,
-		 char * artist, char * record, int * year, char ** tracks) {
+		 char * artist, size_t artist_size, char * record, size_t record_size,
+		 int * year, char ** tracks, size_t tracks_size) {
 
 	cddb_lookup_t * data;
 
@@ -1186,7 +1189,8 @@ cddb_query_batch(int ntracks, int * frames, int length,
 	data->record_length = length;
 
 	cddb_lookup(data);
-	cddb_lookup_merge(data, artist, record, NULL/*genre*/, year, tracks);
+	cddb_lookup_merge(data, artist, artist_size, record, record_size,
+			  NULL/*genre*/, 0, year, tracks, tracks_size);
 	cddb_lookup_free(data);
 }
 

--- a/src/cddb_lookup.c
+++ b/src/cddb_lookup.c
@@ -360,9 +360,9 @@ store_cdda_export_merged(cddb_lookup_t * data, char * artist, char * record, cha
 
 	gtk_tree_model_get(GTK_TREE_MODEL(music_store), &data->iter_record, MS_COL_DATA, &drive, -1);
 
-	strncpy(drive->disc.artist_name, artist, MAXLEN-1);
-	strncpy(drive->disc.record_name, record, MAXLEN-1);
-	strncpy(drive->disc.genre, genre, MAXLEN-1);
+	arr_strlcpy(drive->disc.artist_name, artist);
+	arr_strlcpy(drive->disc.record_name, record);
+	arr_strlcpy(drive->disc.genre, genre);
 	drive->disc.year = year;
 
 	arr_snprintf(name, "%s: %s",
@@ -398,18 +398,18 @@ cddb_lookup_merge(cddb_lookup_t * data, char * artist, size_t artist_size, char 
 
 	for (i = 0; i < data->nrecords; i++) {
 
-		strncpy(tmp, notnull(cddb_disc_get_artist(data->records[i])), MAXLEN-1);
+		arr_strlcpy(tmp, notnull(cddb_disc_get_artist(data->records[i])));
 		if (!is_all_wspace(tmp)) {
 			map_put(&map_artist, tmp);
 		}
 
-		strncpy(tmp, notnull(cddb_disc_get_title(data->records[i])), MAXLEN-1);
+		arr_strlcpy(tmp, notnull(cddb_disc_get_title(data->records[i])));
 		if (!is_all_wspace(tmp)) {
 			map_put(&map_record, tmp);
 		}
 
 		if (genre != NULL) {
-			strncpy(tmp, notnull(cddb_disc_get_genre(data->records[i])), MAXLEN-1);
+			arr_strlcpy(tmp, notnull(cddb_disc_get_genre(data->records[i])));
 			if (!is_all_wspace(tmp)) {
 				map_put(&map_genre, tmp);
 			}
@@ -422,9 +422,7 @@ cddb_lookup_merge(cddb_lookup_t * data, char * artist, size_t artist_size, char 
 		}
 
 		for (j = 0; j < data->ntracks; j++) {
-			strncpy(tmp,
-				notnull(cddb_track_get_title(cddb_disc_get_track(data->records[i], j))),
-				MAXLEN-1);
+			arr_strlcpy(tmp, notnull(cddb_track_get_title(cddb_disc_get_track(data->records[i], j))));
 			if (!is_all_wspace(tmp)) {
 				map_put(map_tracks + j, tmp);
 			}
@@ -913,9 +911,9 @@ store_cdda_export(cddb_lookup_t * data) {
 
 	gtk_tree_model_get(GTK_TREE_MODEL(music_store), &data->iter_record, MS_COL_DATA, &drive, -1);
 
-	strncpy(drive->disc.artist_name, gtk_entry_get_text(GTK_ENTRY(data->artist_entry)), MAXLEN-1);
-	strncpy(drive->disc.record_name, gtk_entry_get_text(GTK_ENTRY(data->title_entry)), MAXLEN-1);
-	strncpy(drive->disc.genre, gtk_entry_get_text(GTK_ENTRY(data->genre_entry)), MAXLEN-1);
+	arr_strlcpy(drive->disc.artist_name, gtk_entry_get_text(GTK_ENTRY(data->artist_entry)));
+	arr_strlcpy(drive->disc.record_name, gtk_entry_get_text(GTK_ENTRY(data->title_entry)));
+	arr_strlcpy(drive->disc.genre, gtk_entry_get_text(GTK_ENTRY(data->genre_entry)));
 	drive->disc.year = gtk_spin_button_get_value(GTK_SPIN_BUTTON(data->year_spinner));
 
 	arr_snprintf(name, "%s: %s",

--- a/src/cddb_lookup.c
+++ b/src/cddb_lookup.c
@@ -365,9 +365,9 @@ store_cdda_export_merged(cddb_lookup_t * data, char * artist, char * record, cha
 	strncpy(drive->disc.genre, genre, MAXLEN-1);
 	drive->disc.year = year;
 
-	snprintf(name, MAXLEN-1, "%s: %s",
-		 drive->disc.artist_name,
-		 drive->disc.record_name);
+	arr_snprintf(name, "%s: %s",
+		     drive->disc.artist_name,
+		     drive->disc.record_name);
 
 	gtk_tree_store_set(music_store, &data->iter_record, MS_COL_NAME, name, -1);
 
@@ -416,7 +416,7 @@ cddb_lookup_merge(cddb_lookup_t * data, char * artist, char * record, char * gen
 
 		y = cddb_disc_get_year(data->records[i]);
 		if (is_valid_year(y)) {
-			snprintf(tmp, MAXLEN-1, "%d", y);
+			arr_snprintf(tmp, "%d", y);
 			map_put(&map_year, tmp);
 		}
 
@@ -472,7 +472,7 @@ query_timeout_cb(gpointer user_data) {
 	case CDDB_INIT:
 		return TRUE;
 	case CDDB_BUSY:
-		snprintf(text, MAXLEN, "%d / %d", data->counter, data->nrecords);
+		arr_snprintf(text, "%d / %d", data->counter, data->nrecords);
 		gtk_progress_bar_set_fraction(GTK_PROGRESS_BAR(data->progbar),
 					      (double)data->counter / data->nrecords);
 		gtk_progress_bar_set_text(GTK_PROGRESS_BAR(data->progbar), text);
@@ -578,9 +578,9 @@ add_to_comments(cddb_lookup_t * data, GtkWidget * entry) {
 
 	if (record_data->comment != NULL && record_data->comment[0] != '\0') {
 		char comment[MAXLEN];
-		snprintf(comment, MAXLEN-1, "%s\n%s",
-			 record_data->comment,
-			 gtk_entry_get_text(GTK_ENTRY(entry)));
+		arr_snprintf(comment, "%s\n%s",
+			     record_data->comment,
+			     gtk_entry_get_text(GTK_ENTRY(entry)));
 		free_strdup(&record_data->comment, comment);
 	} else {
 		free_strdup(&record_data->comment, gtk_entry_get_text(GTK_ENTRY(entry)));
@@ -655,7 +655,7 @@ import_as_year(GtkWidget * widget, gpointer user_data) {
 
 	if (data->year_imported) {
 		char buf[16];
-		snprintf(buf, 15, "%d", year);
+		arr_snprintf(buf, "%d", year);
 		gtk_tree_store_set(music_store, &data->iter_record, MS_COL_SORT, buf, -1);
 	} else {
 		record_data_t * record_data;
@@ -916,9 +916,9 @@ store_cdda_export(cddb_lookup_t * data) {
 	strncpy(drive->disc.genre, gtk_entry_get_text(GTK_ENTRY(data->genre_entry)), MAXLEN-1);
 	drive->disc.year = gtk_spin_button_get_value(GTK_SPIN_BUTTON(data->year_spinner));
 
-	snprintf(name, MAXLEN-1, "%s: %s",
-		 drive->disc.artist_name,
-		 drive->disc.record_name);
+	arr_snprintf(name, "%s: %s",
+		     drive->disc.artist_name,
+		     drive->disc.record_name);
 
 	gtk_tree_store_set(music_store, &data->iter_record, MS_COL_NAME, name, -1);
 }
@@ -967,11 +967,11 @@ cddb_dialog(cddb_lookup_t * data) {
 
         data->combo = gtk_combo_box_new_text();
         for (i = 0; i < data->nrecords; i++) {
-                snprintf(text, MAXLEN, "%d. %s: %s [%x] ",
-                         i + 1,
-                         notnull(cddb_disc_get_artist(data->records[i])),
-                         notnull(cddb_disc_get_title(data->records[i])),
-                         cddb_disc_get_discid(data->records[i]));
+                arr_snprintf(text, "%d. %s: %s [%x] ",
+                             i + 1,
+                             notnull(cddb_disc_get_artist(data->records[i])),
+                             notnull(cddb_disc_get_title(data->records[i])),
+                             cddb_disc_get_discid(data->records[i]));
                 gtk_combo_box_append_text(GTK_COMBO_BOX(data->combo), text);
         }
 

--- a/src/cddb_lookup.c
+++ b/src/cddb_lookup.c
@@ -1098,8 +1098,6 @@ cddb_dialog(cddb_lookup_t * data) {
 
 	cddb_dialog_load_disc(data, data->records[0]);
 
- display:
-
 	if (aqualung_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
 
 		if (iter_get_store_type(&data->iter_record) == STORE_TYPE_FILE) {

--- a/src/cddb_lookup.c
+++ b/src/cddb_lookup.c
@@ -749,44 +749,6 @@ create_cddb_write_warn_dialog(char * text) {
 	return (ret != GTK_RESPONSE_YES);
 }
 
-static int
-check_case(char * text, int _case) {
-
-	char * str;
-	char * p;
-	int has = 0;
-	int ret = 0;
-
-	for (p = text; *p; p = g_utf8_next_char(p)) {
-
-		gunichar ch = g_utf8_get_char(p);
-
-		if (g_unichar_islower(ch) || g_unichar_isupper(ch)) {
-			has = 1;
-			break;
-		}
-	}
-
-	if (!has) {
-		return 1;
-	}
-
-	switch (_case) {
-	case CASE_UP:
-		str = g_utf8_strup(text, -1);
-		ret = strcmp(str, text);
-		g_free(str);
-		break;
-	case CASE_DOWN:
-		str = g_utf8_strdown(text, -1);
-		ret = strcmp(str, text);
-		g_free(str);
-		break;
-	}
-
-	return ret;
-}
-
 
 void
 cddb_dialog_load_disc(cddb_lookup_t * data, cddb_disc_t * disc) {

--- a/src/cddb_lookup.h
+++ b/src/cddb_lookup.h
@@ -29,7 +29,8 @@ void cddb_start_submit(GtkTreeIter * iter_record, int ntracks, int * frames, int
 void cddb_auto_query_cdda(GtkTreeIter * drive_iter, int ntracks, int * frames, int length);
 
 void cddb_query_batch(int ntracks, int * frames, int length,
-		      char * artist, char * record, int * year, char ** tracks);
+		      char * artist, size_t artist_size, char * record, size_t record_size,
+		      int * year, char ** tracks, size_t track_size);
 
 
 #endif /* AQUALUNG_CDDB_LOOKUP_H */

--- a/src/common.h
+++ b/src/common.h
@@ -28,6 +28,25 @@
 #define MAX_COLORNAME_LEN   32
 
 
+/* When built with a C11 compiler, CHAR_ARRAY_SIZE will cause an error if the
+   argument is not actually a char[] array. */
+#if __STDC_VERSION__ >= 201112L
+#define CHAR_ARRAY_SIZE(array) _Generic(&(array), char (*)[]: sizeof(array))
+#else
+#define CHAR_ARRAY_SIZE(array) sizeof(array)
+#endif
+
+/* Since Aqualung uses fixed-size C strings in many places, provide wrappers
+   for bounded string operations that use CHAR_ARRAY_SIZE to ensure it's an
+   array. */
+#define arr_strlcat(dest, src) \
+        g_strlcat((dest), (src), CHAR_ARRAY_SIZE(dest))
+#define arr_strlcpy(dest, src) \
+        g_strlcpy((dest), (src), CHAR_ARRAY_SIZE(dest))
+#define arr_snprintf(dest, ...) \
+        snprintf((dest), CHAR_ARRAY_SIZE(dest), __VA_ARGS__)
+
+
 #endif /* AQUALUNG_COMMON_H */
 
 // vim: shiftwidth=8:tabstop=8:softtabstop=8 :  

--- a/src/core.c
+++ b/src/core.c
@@ -1925,7 +1925,7 @@ load_default_cl(int * argc, char *** argv) {
                 }
         }
 
-        sprintf(config_file, "%s/config.xml", options.confdir);
+        arr_snprintf(config_file, "%s/config.xml", options.confdir);
         if ((f = fopen(config_file, "rt")) == NULL) {
                 fprintf(stderr, "No config.xml -- creating empty one: %s\n", config_file);
                 fprintf(stderr, "Wired-in defaults will be used.\n");
@@ -2830,7 +2830,7 @@ main(int argc, char ** argv) {
 	if (no_session != -1) {
 		char sockname[MAXLEN];
 
-		sprintf(sockname, "/tmp/aqualung_%s.%d", g_get_user_name(), no_session);
+		arr_snprintf(sockname, "/tmp/aqualung_%s.%d", g_get_user_name(), no_session);
 		if (!g_file_test(sockname, G_FILE_TEST_EXISTS)) {
 			no_session = -1;
 		}

--- a/src/core.c
+++ b/src/core.c
@@ -2845,7 +2845,7 @@ main(int argc, char ** argv) {
 
 			for (i = optind; argv[i] != NULL; i++) {				
 
-				normalize_filename(argv[i], fullname);
+				normalize_filename(argv[i], fullname, CHAR_ARRAY_SIZE(fullname));
 
 				buffer[0] = RCMD_ADD_FILE;
 				buffer[1] = '\0';

--- a/src/core.c
+++ b/src/core.c
@@ -355,7 +355,7 @@ disk_thread(void * arg) {
 				strcpy(filename_prev, filename);
 #endif /* HAVE_CDDA */
 				if (cue.filename != NULL) {
-					strncpy(filename, cue.filename, MAXLEN-1);
+					arr_strlcpy(filename, cue.filename);
 					free(cue.filename);
 				} else {
 					filename[0] = '\0';
@@ -1965,7 +1965,7 @@ load_default_cl(int * argc, char *** argv) {
                 if ((!xmlStrcmp(cur->name, (const xmlChar *)"default_param"))) {
                         key = xmlNodeListGetString(doc, cur->xmlChildrenNode, 1);
                         if (key != NULL)
-                                strncpy(default_param, (char *) key, MAXLEN-1);
+                                arr_strlcpy(default_param, (char *) key);
                         xmlFree(key);
                 }
                 cur = cur->next;
@@ -2380,7 +2380,7 @@ setup_app_directories(void) {
 			exit(1);
 		}
 	}
-	strncpy(options.confdir, xdgconfdir, MAXLEN-1);
+	arr_strlcpy(options.confdir, xdgconfdir);
 	g_free(xdgconfdir);
 
 	strcpy(options.audiodir, options.home);

--- a/src/core.c
+++ b/src/core.c
@@ -352,7 +352,7 @@ disk_thread(void * arg) {
 				rb_read(rb_gui2disk, (void *)&cue, sizeof(cue_t));
 				
 #ifdef HAVE_CDDA
-				strcpy(filename_prev, filename);
+				arr_strlcpy(filename_prev, filename);
 #endif /* HAVE_CDDA */
 				if (cue.filename != NULL) {
 					arr_strlcpy(filename, cue.filename);
@@ -2361,10 +2361,10 @@ setup_app_directories(void) {
         char * xdgconfdir;
 	if (!home) {
 		char * homedir = (char *)g_get_home_dir();
-		strcpy(options.home, homedir);
+		arr_strlcpy(options.home, homedir);
 		g_free(homedir);
 	} else {
-		strcpy(options.home, home);
+		arr_strlcpy(options.home, home);
 	}
 
 	arr_snprintf(options.confdir, "%s/.aqualung", options.home);
@@ -2383,17 +2383,17 @@ setup_app_directories(void) {
 	arr_strlcpy(options.confdir, xdgconfdir);
 	g_free(xdgconfdir);
 
-	strcpy(options.audiodir, options.home);
-	strcpy(options.currdir, options.home);
-	strcpy(options.exportdir, options.home);
-	strcpy(options.plistdir, options.home);
-	strcpy(options.podcastdir, options.home);
-	strcpy(options.ripdir, options.home);
-	strcpy(options.storedir, options.home);
+	arr_strlcpy(options.audiodir, options.home);
+	arr_strlcpy(options.currdir, options.home);
+	arr_strlcpy(options.exportdir, options.home);
+	arr_strlcpy(options.plistdir, options.home);
+	arr_strlcpy(options.podcastdir, options.home);
+	arr_strlcpy(options.ripdir, options.home);
+	arr_strlcpy(options.storedir, options.home);
 
 	if (getcwd(options.cwd, MAXLEN) == NULL) {
 		fprintf(stderr, "setup_app_directories(): warning: getcwd() returned NULL, using . as cwd\n");
-		strcpy(options.cwd, ".");
+		arr_strlcpy(options.cwd, ".");
 	}
 }
 

--- a/src/core.c
+++ b/src/core.c
@@ -1973,7 +1973,7 @@ load_default_cl(int * argc, char *** argv) {
 
         xmlFreeDoc(doc);
 
-	snprintf(cl, MAXLEN-1, "aqualung %s", default_param);
+	arr_snprintf(cl, "aqualung %s", default_param);
 	while (cl[i] != '\0') {
 		++(*argc);
 		if ((*argv = realloc(*argv, *argc * sizeof(char *))) == NULL) {
@@ -2367,7 +2367,7 @@ setup_app_directories(void) {
 		strcpy(options.home, home);
 	}
 
-	snprintf(options.confdir, MAXLEN-1, "%s/.aqualung", options.home);
+	arr_snprintf(options.confdir, "%s/.aqualung", options.home);
         xdgconfdir = g_build_filename(g_get_user_config_dir(), "aqualung", NULL);
 	if (!g_file_test(xdgconfdir, G_FILE_TEST_IS_DIR) &&
 	    g_file_test(options.confdir, G_FILE_TEST_IS_DIR)) {

--- a/src/core.c
+++ b/src/core.c
@@ -2810,7 +2810,7 @@ main(int argc, char ** argv) {
 			no_session = 0;
 		buf[0] = RCMD_VOLADJ;
 		buf[1] = '\0';
-		strncat(buf, voladj_arg, MAXLEN-2);
+		arr_strlcat(buf, voladj_arg);
 		send_message_to_session(no_session, buf, strlen(buf));
 		exit(1);
 	}
@@ -2822,7 +2822,7 @@ main(int argc, char ** argv) {
 			no_session = 0;
 		buf[0] = RCMD_CUSTOM;
 		buf[1] = '\0';
-		strncat(buf, custom_arg, MAXLEN-2);
+		arr_strlcat(buf, custom_arg);
 		send_message_to_session(no_session, buf, strlen(buf));
 		exit(0);
 	}
@@ -2849,7 +2849,7 @@ main(int argc, char ** argv) {
 
 				buffer[0] = RCMD_ADD_FILE;
 				buffer[1] = '\0';
-				strncat(buffer, fullname, MAXLEN-2);
+				arr_strlcat(buffer, fullname);
 				send_message_to_session(no_session, buffer, strlen(buffer));
 			}
 
@@ -2862,7 +2862,7 @@ main(int argc, char ** argv) {
 				buffer[4] = '\0';
 
 				if (tab_name != NULL) {
-					strncat(buffer + 4, tab_name, MAXLEN-5);
+					g_strlcat(buffer + 4, tab_name, CHAR_ARRAY_SIZE(buffer) - 4);
 				}
 
 				send_message_to_session(no_session, buffer, 4 + strlen(buffer + 4));

--- a/src/cover.c
+++ b/src/cover.c
@@ -105,7 +105,7 @@ entry_filter(const struct dirent *entry) {
                                 g_free(str1);
                                 g_free(str2);
                                 ext_flag = TRUE;
-                                strncpy(temp_filename, entry->d_name, PATH_MAX-1);
+                                arr_strlcpy(temp_filename, entry->d_name);
                                 return TRUE;
                         }
                 

--- a/src/cover.c
+++ b/src/cover.c
@@ -151,8 +151,8 @@ find_cover_filename(gchar *song_filename) {
                         for (j = 0; j < n_extensions; j++) {
 
                                 strcpy (current_filename, cover_filenames[i]);
-                                strcat (current_filename, ".");
-                                strcat (current_filename, cover_extensions[j]);
+                                arr_strlcat(current_filename, ".");
+                                arr_strlcat(current_filename, cover_extensions[j]);
 
                                 str1 = g_utf8_casefold (current_filename, -1);
 
@@ -163,7 +163,7 @@ find_cover_filename(gchar *song_filename) {
                                         if (!g_utf8_collate(str1, str2)) {
 
                                                 strcpy (cover_filename, base_path);
-                                                strcat (cover_filename, d_entry[n]->d_name);
+                                                arr_strlcat(cover_filename, d_entry[n]->d_name);
 
                                                 if (g_file_test (cover_filename, G_FILE_TEST_IS_REGULAR) == TRUE) {
                                                         g_free (str1);
@@ -198,7 +198,7 @@ find_cover_filename(gchar *song_filename) {
                 strcpy (cover_filename, base_path);
  
                 if (ext_flag == TRUE) {
-                        strcat (cover_filename, temp_filename);
+                        arr_strlcat(cover_filename, temp_filename);
                         cover_filename_reasonable = TRUE;
                 }
 

--- a/src/cover.c
+++ b/src/cover.c
@@ -136,7 +136,7 @@ find_cover_filename(gchar *song_filename) {
 
 
         n_templates = sizeof(cover_filenames) / sizeof(gchar*);
-        strcpy(base_path, get_song_path(song_filename));
+        arr_strlcpy(base_path, get_song_path(song_filename));
 
         if (strcmp(base_path, get_song_path(cover_filename))) {
 
@@ -150,7 +150,7 @@ find_cover_filename(gchar *song_filename) {
 
                         for (j = 0; j < n_extensions; j++) {
 
-                                strcpy (current_filename, cover_filenames[i]);
+                                arr_strlcpy(current_filename, cover_filenames[i]);
                                 arr_strlcat(current_filename, ".");
                                 arr_strlcat(current_filename, cover_extensions[j]);
 
@@ -162,7 +162,7 @@ find_cover_filename(gchar *song_filename) {
 
                                         if (!g_utf8_collate(str1, str2)) {
 
-                                                strcpy (cover_filename, base_path);
+                                                arr_strlcpy(cover_filename, base_path);
                                                 arr_strlcat(cover_filename, d_entry[n]->d_name);
 
                                                 if (g_file_test (cover_filename, G_FILE_TEST_IS_REGULAR) == TRUE) {
@@ -195,7 +195,7 @@ find_cover_filename(gchar *song_filename) {
                         free(d_entry);
                 }
 
-                strcpy (cover_filename, base_path);
+                arr_strlcpy(cover_filename, base_path);
  
                 if (ext_flag == TRUE) {
                         arr_strlcat(cover_filename, temp_filename);
@@ -430,7 +430,7 @@ display_cover(GtkWidget *image_area, GtkWidget *event_area, GtkWidget *align,
 		return;
 	}
 
-	strcpy(cover_filename, filename);
+	arr_strlcpy(cover_filename, filename);
 
 	if ((cover_pixbuf = gdk_pixbuf_new_from_file(cover_filename, NULL)) != NULL) {
 		display_cover_from_pixbuf(image_area, event_area, align,
@@ -525,7 +525,7 @@ insert_cover(GtkTreeIter * tree_iter, GtkTextIter * text_iter, GtkTextBuffer * b
 		return;
 	}
 
-	strcpy(cover_filename, filename);
+	arr_strlcpy(cover_filename, filename);
 
 	/* load and display cover */
 

--- a/src/decoder/dec_cdda.c
+++ b/src/decoder/dec_cdda.c
@@ -358,7 +358,7 @@ cdda_decoder_open(decoder_t * dec, char * filename) {
 
 	fdec->file_lib = CDDA_LIB;
 	fdec->fileinfo.bps = 2 * 16 * 44100;
-	strcpy(dec->format_str, "Audio CD");
+	arr_strlcpy(dec->format_str, "Audio CD");
 
 	return DECODER_OPEN_SUCCESS;
 }

--- a/src/decoder/dec_flac.c
+++ b/src/decoder/dec_flac.c
@@ -495,7 +495,7 @@ flac_decoder_open(decoder_t * dec, char * filename) {
 				* fdec->fileinfo.channels;
 
 			fdec->file_lib = FLAC_LIB;
-			strcpy(dec->format_str, "FLAC");
+			arr_strlcpy(dec->format_str, "FLAC");
 
 			flac_send_metadata(dec);
 			return DECODER_OPEN_SUCCESS;

--- a/src/decoder/dec_lavc.c
+++ b/src/decoder/dec_lavc.c
@@ -323,7 +323,7 @@ lavc_decoder_open(decoder_t * dec, char * filename) {
 	}
 
 	fdec->file_lib = LAVC_LIB;
-	snprintf(dec->format_str, MAXLEN-1, "%s/%s", pd->avFormatCtx->iformat->name, pd->avCodec->name);
+	arr_snprintf(dec->format_str, "%s/%s", pd->avFormatCtx->iformat->name, pd->avCodec->name);
 	for (i = 0; dec->format_str[i] != '\0'; i++) {
 		dec->format_str[i] = toupper(dec->format_str[i]);
 	}

--- a/src/decoder/dec_mac.cpp
+++ b/src/decoder/dec_mac.cpp
@@ -238,7 +238,7 @@ mac_decoder_open(decoder_t * dec, char * filename) {
 		break;
 	}
 
-	sprintf(dec->format_str, "Monkey's Audio%s%s%s", (comp_level != NULL) ? " (" : "", comp_level, (comp_level != NULL) ? ")" : "");
+	arr_snprintf(dec->format_str, "Monkey's Audio%s%s%s", (comp_level != NULL) ? " (" : "", comp_level, (comp_level != NULL) ? ")" : "");
 
 	meta = metadata_new();
 	meta_ape_send_metadata(meta, fdec);

--- a/src/decoder/dec_mod.c
+++ b/src/decoder/dec_mod.c
@@ -267,7 +267,7 @@ mod_name_filter(char *str) {
         char buffer[MAXLEN];
         int n, k, f, len;
 
-        strncpy(buffer, str, MAXLEN-1);
+        arr_strlcpy(buffer, str);
 
         k = f = n = 0;
         len = strlen(buffer);
@@ -300,7 +300,7 @@ mod_filename_filter(char *str, char **valid_extensions) {
         char *pos;
         int i;
 
-        strncpy(buffer, str, MAXLEN-1);
+        arr_strlcpy(buffer, str);
 
         if ((pos = strrchr(buffer, '/')) != NULL) {
 
@@ -333,7 +333,7 @@ mod_filename_filter(char *str, char **valid_extensions) {
             }
         }
 
-        strncpy(buffer, str, MAXLEN-1);
+        arr_strlcpy(buffer, str);
 
         if ((pos = strchr(buffer, '.')) != NULL) {
             *pos = '\0';
@@ -381,11 +381,11 @@ mod_send_metadata(decoder_t * dec) {
 
 	memset(&mi, 0x00, sizeof(mod_info));
 
-	strncpy(mi.title, ModPlug_GetName(pd->mpf), MAXLEN-1);
+	arr_strlcpy(mi.title, ModPlug_GetName(pd->mpf));
 	mod_name_filter(mi.title);
 
 	if (!strlen(mi.title)) {
-		strncpy(mi.title, fdec->filename, MAXLEN-1);
+		arr_strlcpy(mi.title, fdec->filename);
 		mod_filename_filter(mi.title, valid_extensions_mod);
 		mod_name_filter(mi.title);
 	}

--- a/src/decoder/dec_mod.c
+++ b/src/decoder/dec_mod.c
@@ -31,6 +31,7 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <glib.h>
 
 #ifdef HAVE_LIBZ
 #include <zlib.h>
@@ -99,7 +100,7 @@ unpack_file (char *filename, int type) {
 			}
 		}
 
-		strncat(unpacked_filename, "/tmp/", PATH_MAX-1);
+		arr_strlcat(unpacked_filename, "/tmp/");
 
 		i = 5;      /* strlen("/tmp/") */
 

--- a/src/decoder/dec_mod.c
+++ b/src/decoder/dec_mod.c
@@ -505,7 +505,7 @@ char *filename = NULL;
 	fdec->fileinfo.channels = pd->mp_settings.mChannels;
 	fdec->fileinfo.sample_rate = pd->mp_settings.mFrequency;
 	fdec->file_lib = MOD_LIB;
-	strcpy(dec->format_str, "MOD Audio");
+	arr_strlcpy(dec->format_str, "MOD Audio");
 
 	fdec->fileinfo.total_samples = ModPlug_GetLength(pd->mpf)
 		/ 1000.0f * pd->mp_settings.mFrequency;

--- a/src/decoder/dec_mpc.c
+++ b/src/decoder/dec_mpc.c
@@ -270,7 +270,7 @@ mpc_decoder_open(decoder_t * dec, char * filename) {
 		break;
 	}
 
-	sprintf(dec->format_str, "Musepack%s%s%s", (profile != NULL) ? " (" : "", profile, (profile != NULL) ? ")" : "");
+	arr_snprintf(dec->format_str, "Musepack%s%s%s", (profile != NULL) ? " (" : "", profile, (profile != NULL) ? ")" : "");
 
 	meta = metadata_new();
 	mpc_add_rg_meta(meta, &pd->mpc_i);

--- a/src/decoder/dec_mpeg.c
+++ b/src/decoder/dec_mpeg.c
@@ -1152,59 +1152,59 @@ mpeg_decoder_finish_open(decoder_t * dec) {
 	strcpy(dec->format_str, "MPEG Audio");
 
 	if (pd->mpeg_subformat & 0xff7) {
-		strcat(dec->format_str, " (");
+		arr_strlcat(dec->format_str, " (");
 		switch (pd->mpeg_subformat & MPEG_LAYER_MASK) {
 		case MPEG_LAYER_I:
-			strcat(dec->format_str, _("Layer I"));
+			arr_strlcat(dec->format_str, _("Layer I"));
 			break;
 		case MPEG_LAYER_II:
-			strcat(dec->format_str, _("Layer II"));
+			arr_strlcat(dec->format_str, _("Layer II"));
 			break;
 		case MPEG_LAYER_III:
-			strcat(dec->format_str, _("Layer III"));
+			arr_strlcat(dec->format_str, _("Layer III"));
 			break;
 		default:
-			strcat(dec->format_str, _("Unrecognized"));
+			arr_strlcat(dec->format_str, _("Unrecognized"));
 			break;
 		}
 	}
 
 	if ((pd->mpeg_subformat & MPEG_LAYER_MASK) && (pd->mpeg_subformat & (MPEG_MODE_MASK | MPEG_EMPH_MASK)))
-		strcat(dec->format_str, ", ");
+		arr_strlcat(dec->format_str, ", ");
 	switch (pd->mpeg_subformat & MPEG_MODE_MASK) {
 	case MPEG_MODE_SINGLE:
-		strcat(dec->format_str, _("Single channel"));
+		arr_strlcat(dec->format_str, _("Single channel"));
 		break;
 	case MPEG_MODE_DUAL:
-		strcat(dec->format_str, _("Dual channel"));
+		arr_strlcat(dec->format_str, _("Dual channel"));
 		break;
 	case MPEG_MODE_JOINT:
-		strcat(dec->format_str, _("Joint stereo"));
+		arr_strlcat(dec->format_str, _("Joint stereo"));
 		break;
 	case MPEG_MODE_STEREO:
-		strcat(dec->format_str, _("Stereo"));
+		arr_strlcat(dec->format_str, _("Stereo"));
 		break;
 	}
 
 	if ((pd->mpeg_subformat & MPEG_MODE_MASK) && (pd->mpeg_subformat & MPEG_EMPH_MASK))
-		strcat(dec->format_str, ", ");
+		arr_strlcat(dec->format_str, ", ");
 	switch (pd->mpeg_subformat & MPEG_EMPH_MASK) {
 	case MPEG_EMPH_NONE:
-		strcat(dec->format_str, _("Emphasis: none"));
+		arr_strlcat(dec->format_str, _("Emphasis: none"));
 		break;
 	case MPEG_EMPH_5015:
-		strcat(dec->format_str, _("Emphasis:"));
-		strcat(dec->format_str, " 50/15 us");
+		arr_strlcat(dec->format_str, _("Emphasis:"));
+		arr_strlcat(dec->format_str, " 50/15 us");
 		break;
 	case MPEG_EMPH_J_17:
-		strcat(dec->format_str, _("Emphasis:"));
-		strcat(dec->format_str, " CCITT J.17");
+		arr_strlcat(dec->format_str, _("Emphasis:"));
+		arr_strlcat(dec->format_str, " CCITT J.17");
 		break;
 	case MPEG_EMPH_RES:
-		strcat(dec->format_str, _("Emphasis: reserved"));
+		arr_strlcat(dec->format_str, _("Emphasis: reserved"));
 		break;
 	}
-	strcat(dec->format_str, ")");
+	arr_strlcat(dec->format_str, ")");
 
 	fdec->fileinfo.total_samples = pd->total_samples_est;
 	fdec->fileinfo.bps = pd->bitrate;

--- a/src/decoder/dec_mpeg.c
+++ b/src/decoder/dec_mpeg.c
@@ -1149,7 +1149,7 @@ mpeg_decoder_finish_open(decoder_t * dec) {
 	fdec->fileinfo.channels = pd->channels;
 	fdec->fileinfo.sample_rate = pd->SR;
 	fdec->file_lib = MAD_LIB;
-	strcpy(dec->format_str, "MPEG Audio");
+	arr_strlcpy(dec->format_str, "MPEG Audio");
 
 	if (pd->mpeg_subformat & 0xff7) {
 		arr_strlcat(dec->format_str, " (");

--- a/src/decoder/dec_null.c
+++ b/src/decoder/dec_null.c
@@ -90,7 +90,7 @@ null_decoder_open(decoder_t * dec, char * filename) {
 	   If opening was successful, put a string describing the
 	   format/decoder in format_str[]:
 
-	   strcpy(dec->format_str, "NULL Audio");
+	   arr_strlcpy(dec->format_str, "NULL Audio");
 	*/
 
 	return DECODER_OPEN_BADLIB;

--- a/src/decoder/dec_sndfile.c
+++ b/src/decoder/dec_sndfile.c
@@ -292,7 +292,7 @@ sndfile_decoder_open(decoder_t * dec, char * filename) {
 		break;
 	}
 
-	sprintf(dec->format_str, "%s%s%s%s%s", format_type, (format_sub1 != NULL) ? " (" : "", format_sub1, format_sub2, (format_sub1 != NULL) ? ")" : "");
+	arr_snprintf(dec->format_str, "%s%s%s%s%s", format_type, (format_sub1 != NULL) ? " (" : "", format_sub1, format_sub2, (format_sub1 != NULL) ? ")" : "");
 
 	return DECODER_OPEN_SUCCESS;
 }

--- a/src/decoder/dec_speex.c
+++ b/src/decoder/dec_speex.c
@@ -272,7 +272,7 @@ speex_dec_open(decoder_t * dec, char * filename) {
 	fdec->fileinfo.bps = 8 * length_in_bytes / (length_in_samples / pd->sample_rate);
 
 	fdec->file_lib = SPEEX_LIB;
-	strcpy(dec->format_str, "Ogg Speex");
+	arr_strlcpy(dec->format_str, "Ogg Speex");
 
 	return DECODER_OPEN_SUCCESS;
 }

--- a/src/decoder/dec_vorbis.c
+++ b/src/decoder/dec_vorbis.c
@@ -285,7 +285,7 @@ vorbis_decoder_finish_open(decoder_t * dec) {
 	fdec->fileinfo.bps = ov_bitrate(&(pd->vf), -1);
 
 	fdec->file_lib = VORBIS_LIB;
-	strcpy(dec->format_str, "Ogg Vorbis");
+	arr_strlcpy(dec->format_str, "Ogg Vorbis");
 
 	vorbis_send_metadata(fdec, pd);
 	vorbis_decoder_send_metadata(dec);

--- a/src/decoder/dec_wavpack.c
+++ b/src/decoder/dec_wavpack.c
@@ -142,7 +142,7 @@ wavpack_decoder_open(decoder_t * dec, char * filename) {
 	/* Opening hybrid correction file if possible */
 	pd->flags = OPEN_2CH_MAX | OPEN_TAGS | OPEN_NORMALIZE | OPEN_WVC;
 
-	strcpy(pd->error, "No Error");
+	arr_strlcpy(pd->error, "No Error");
 	pd->wpc = WavpackOpenFileInput(filename, pd->error, pd->flags, 0);
 
 	/* The decoder can actually do something with the file */
@@ -171,7 +171,7 @@ wavpack_decoder_open(decoder_t * dec, char * filename) {
 			pd->scale_factor_float *= 2;
 		}
 
-		strcpy(dec->format_str, "WavPack");
+		arr_strlcpy(dec->format_str, "WavPack");
 		fdec->file_lib = WAVPACK_LIB;
 
 		meta = metadata_new();

--- a/src/encoder/enc_vorbis.c
+++ b/src/encoder/enc_vorbis.c
@@ -108,10 +108,10 @@ vorbisenc_encoder_open(encoder_t * enc, encoder_mode_t * mode) {
 			if (META_FIELD_TEXT(frame->type)) {
 				field_val = frame->field_val;
 			} else if (META_FIELD_INT(frame->type)) {
-				snprintf(fval, MAXLEN-1, renderfmt, frame->int_val);
+				arr_snprintf(fval, renderfmt, frame->int_val);
 				field_val = fval;
 			} else if (META_FIELD_FLOAT(frame->type)) {
-				snprintf(fval, MAXLEN-1, renderfmt, frame->float_val);
+				arr_snprintf(fval, renderfmt, frame->float_val);
 				field_val = fval;
 			}
 

--- a/src/encoder/file_encoder.c
+++ b/src/encoder/file_encoder.c
@@ -75,11 +75,6 @@ file_encoder_open(file_encoder_t * fenc, encoder_mode_t * mode) {
 
 	encoder_t * enc;
 
-	if (mode->filename == NULL) {
-		fprintf(stderr, "error: filename == NULL passed to file_encoder_open()\n");
-		return 1;
-	}
-
 	enc = encoder_init_v[mode->file_lib](fenc);
 	if (!enc) {
 		fprintf(stderr, "error initializing encoder %d.\n", mode->file_lib);

--- a/src/export.c
+++ b/src/export.c
@@ -1031,7 +1031,7 @@ export_dialog_response(GtkDialog * dialog, gint response_id, gpointer ex) {
 		char * format = (char *)gtk_entry_get_text(GTK_ENTRY(export->templ_entry));
 		if ((ret = make_string_va(buf, format,
 					  'o', "o", 'a', "a", 'r', "r", 't', "t", 'n', "n", 'x', "x", 'i', "i", 0)) != 0) {
-			make_string_strerror(ret, buf);
+			make_string_strerror(ret, buf, CHAR_ARRAY_SIZE(buf));
 			message_dialog(_("Error in format string"),
 				       export->dialog,
 				       GTK_MESSAGE_ERROR,

--- a/src/export.c
+++ b/src/export.c
@@ -299,7 +299,7 @@ export_finish(gpointer user_data) {
 }
 
 int
-export_item_set_path(export_t * export, export_item_t * item, char * path, char * ext, int index) {
+export_item_set_path(export_t * export, export_item_t * item, char * path, size_t path_len, char * ext, int index) {
 
 	char track[MAXLEN];
 	char buf[3*MAXLEN];
@@ -329,13 +329,13 @@ export_item_set_path(export_t * export, export_item_t * item, char * path, char 
 		}
 	}
 
-	snprintf(str_no, 15, "%02d", item->no);
-	snprintf(str_index, 15, "%04d", index);
+	arr_snprintf(str_no, "%02d", item->no);
+	arr_snprintf(str_index, "%04d", index);
 
 	make_string_va(track, export->template, 'o', item->original, 'a', item->artist,
 		       'r', item->album, 't', item->title, 'n', str_no, 'x', ext, 'i', str_index, 0);
 
-	snprintf(path, MAXLEN-1, "%s/%s", buf, track);
+	snprintf(path, path_len, "%s/%s", buf, track);
 	return 0;
 }
 
@@ -583,7 +583,7 @@ export_item(export_t * export, export_item_t * item, int index) {
 		}
 	}
 
-	if (export_item_set_path(export, item, filename, ext, index) < 0) {
+	if (export_item_set_path(export, item, filename, CHAR_ARRAY_SIZE(filename), ext, index) < 0) {
 		file_decoder_close(fdec);
 		file_decoder_delete(fdec);
 		return;

--- a/src/export.c
+++ b/src/export.c
@@ -1055,8 +1055,8 @@ export_dialog_response(GtkDialog * dialog, gint response_id, gpointer ex) {
 	}
 	
 	strncpy(options.exportdir, export->outdir, MAXLEN-1);
-	set_option_from_entry(export->templ_entry, export->template, MAXLEN);
-	set_option_from_entry(export->templ_entry, options.export_template, MAXLEN);
+	set_option_from_entry(export->templ_entry, export->template, CHAR_ARRAY_SIZE(export->template));
+	set_option_from_entry(export->templ_entry, options.export_template, CHAR_ARRAY_SIZE(options.export_template));
 	options.export_file_format = export->format = export_get_format_from_combo(export->format_combo);
 	options.export_bitrate = export->bitrate = gtk_range_get_value(GTK_RANGE(export->bitrate_scale));
 	set_option_from_toggle(export->check_dir_artist, &options.export_subdir_artist);
@@ -1075,7 +1075,7 @@ export_dialog_response(GtkDialog * dialog, gint response_id, gpointer ex) {
 	options.export_excl_enabled = export->excl_enabled;
 	
 	if (export->excl_enabled) {
-		set_option_from_entry(export->excl_entry, options.export_excl_pattern, MAXLEN);
+		set_option_from_entry(export->excl_entry, options.export_excl_pattern, CHAR_ARRAY_SIZE(options.export_excl_pattern));
 		export->excl_patternv =
 			g_strsplit(gtk_entry_get_text(GTK_ENTRY(export->excl_entry)), ",", 0);
 	}

--- a/src/export.c
+++ b/src/export.c
@@ -309,11 +309,11 @@ export_item_set_path(export_t * export, export_item_t * item, char * path, size_
 	track[0] = '\0';
 	buf[0] = '\0';
 
-	strcat(buf, export->outdir);
+	arr_strlcat(buf, export->outdir);
 
 	if (export->dir_for_artist) {
-		strcat(buf, "/");
-		strcat(buf, export_map_put(&export->artist_map, item->artist, export->dir_len_limit));
+		arr_strlcat(buf, "/");
+		arr_strlcat(buf, export_map_put(&export->artist_map, item->artist, export->dir_len_limit));
 		if (!is_dir(buf) && mkdir(buf, S_IRUSR | S_IWUSR | S_IXUSR) < 0) {
 			fprintf(stderr, "mkdir: %s: %s\n", buf, strerror(errno));
 			return -1;
@@ -321,8 +321,8 @@ export_item_set_path(export_t * export, export_item_t * item, char * path, size_
 	}
 
 	if (export->dir_for_album) {
-		strcat(buf, "/");
-		strcat(buf, export_map_put(&export->record_map, item->album, export->dir_len_limit));
+		arr_strlcat(buf, "/");
+		arr_strlcat(buf, export_map_put(&export->record_map, item->album, export->dir_len_limit));
 		if (!is_dir(buf) && mkdir(buf, S_IRUSR | S_IWUSR | S_IXUSR) < 0) {
 			fprintf(stderr, "mkdir: %s: %s\n", buf, strerror(errno));
 			return -1;

--- a/src/export.c
+++ b/src/export.c
@@ -405,7 +405,7 @@ void
 set_prog_src_file_entry(export_t * export, char * file) {
 
 	AQUALUNG_MUTEX_LOCK(export->mutex);
-	strncpy(export->file1, file, MAXLEN-1);
+	arr_strlcpy(export->file1, file);
         AQUALUNG_MUTEX_UNLOCK(export->mutex);
 
 	aqualung_idle_add(set_prog_src_file_entry_idle, export);
@@ -415,7 +415,7 @@ void
 set_prog_trg_file_entry(export_t * export, char * file) {
 
 	AQUALUNG_MUTEX_LOCK(export->mutex);
-	strncpy(export->file2, file, MAXLEN-1);
+	arr_strlcpy(export->file2, file);
         AQUALUNG_MUTEX_UNLOCK(export->mutex);
 
 	aqualung_idle_add(set_prog_trg_file_entry_idle, export);
@@ -641,7 +641,7 @@ export_item(export_t * export, export_item_t * item, int index) {
 	}
 
 
-	strncpy(mode.filename, filename, MAXLEN-1);
+	arr_strlcpy(mode.filename, filename);
 	mode.file_lib = export->format;
 	mode.sample_rate = fdec->fileinfo.sample_rate;
 	mode.channels = fdec->fileinfo.channels;
@@ -1055,7 +1055,7 @@ export_dialog_response(GtkDialog * dialog, gint response_id, gpointer ex) {
 		return FALSE;
 	}
 	
-	strncpy(options.exportdir, export->outdir, MAXLEN-1);
+	arr_strlcpy(options.exportdir, export->outdir);
 	set_option_from_entry(export->templ_entry, export->template, CHAR_ARRAY_SIZE(export->template));
 	set_option_from_entry(export->templ_entry, options.export_template, CHAR_ARRAY_SIZE(options.export_template));
 	options.export_file_format = export->format = export_get_format_from_combo(export->format_combo);

--- a/src/export.c
+++ b/src/export.c
@@ -1019,7 +1019,7 @@ export_dialog_response(GtkDialog * dialog, gint response_id, gpointer ex) {
 		return FALSE;
 	}
 	
-	normalize_filename(poutdir, export->outdir);
+	normalize_filename(poutdir, export->outdir, CHAR_ARRAY_SIZE(export->outdir));
 	g_free(poutdir);
 	
 	if (strlen(gtk_entry_get_text(GTK_ENTRY(export->templ_entry))) == 0) {

--- a/src/export.c
+++ b/src/export.c
@@ -349,7 +349,7 @@ update_progbar_ratio(gpointer user_data) {
 		char tmp[16];
 
 		AQUALUNG_MUTEX_LOCK(export->mutex);
-		snprintf(tmp, 15, "%d%%", (int)(export->ratio * 100));
+		arr_snprintf(tmp, "%d%%", (int)(export->ratio * 100));
 		gtk_progress_bar_set_fraction(GTK_PROGRESS_BAR(export->progbar), export->ratio);
 		AQUALUNG_MUTEX_UNLOCK(export->mutex);
 		gtk_progress_bar_set_text(GTK_PROGRESS_BAR(export->progbar), tmp);
@@ -455,7 +455,7 @@ export_meta_amend_frame(metadata_t * meta, int tag, int type, export_item_t * it
 	case META_FIELD_DATE:
 		{
 			char str_year[6];
-			snprintf(str_year, 5, "%d", item->year);
+			arr_snprintf(str_year, "%d", item->year);
 			frame->field_val = strdup(str_year);
 		}
 		break;
@@ -855,11 +855,11 @@ export_bitrate_changed(GtkRange * range, gpointer data) {
 		switch (i) {
 		case 0:
 		case 8:
-			snprintf(str, 255, "%d (%s)", i, (i == 0) ? _("fast") : _("best"));
+			arr_snprintf(str, "%d (%s)", i, (i == 0) ? _("fast") : _("best"));
 			gtk_label_set_text(GTK_LABEL(export->bitrate_value_label), str);
 			break;
 		default:
-			snprintf(str, 255, "%d", i);
+			arr_snprintf(str, "%d", i);
 			gtk_label_set_text(GTK_LABEL(export->bitrate_value_label), str);
 			break;
 		}
@@ -867,7 +867,7 @@ export_bitrate_changed(GtkRange * range, gpointer data) {
 	if (strcmp(text, "Ogg Vorbis") == 0) {
 		int i = (int)val;
 		char str[256];
-		snprintf(str, 255, "%d", i);
+		arr_snprintf(str, "%d", i);
 		gtk_label_set_text(GTK_LABEL(export->bitrate_value_label), str);
 	}
 	if (strcmp(text, "MP3") == 0) {
@@ -876,7 +876,7 @@ export_bitrate_changed(GtkRange * range, gpointer data) {
 #ifdef HAVE_LAME
 		i = lame_encoder_validate_bitrate(i, 0);
 #endif /* HAVE_LAME */
-		snprintf(str, 255, "%d", i);
+		arr_snprintf(str, "%d", i);
 		gtk_label_set_text(GTK_LABEL(export->bitrate_value_label), str);
 	}
 	g_free(text);

--- a/src/export.c
+++ b/src/export.c
@@ -727,7 +727,7 @@ export_browse_cb(GtkButton * button, gpointer data) {
 				GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
 				FILE_CHOOSER_FILTER_NONE,
 				(GtkWidget *)data,
-				options.exportdir);
+				options.exportdir, CHAR_ARRAY_SIZE(options.exportdir));
 }
 
 GtkWidget *

--- a/src/export.c
+++ b/src/export.c
@@ -332,8 +332,9 @@ export_item_set_path(export_t * export, export_item_t * item, char * path, size_
 	arr_snprintf(str_no, "%02d", item->no);
 	arr_snprintf(str_index, "%04d", index);
 
-	make_string_va(track, export->template, 'o', item->original, 'a', item->artist,
-		       'r', item->album, 't', item->title, 'n', str_no, 'x', ext, 'i', str_index, 0);
+	make_string_va(track, CHAR_ARRAY_SIZE(track), export->template,
+		       'o', item->original, 'a', item->artist, 'r', item->album,
+		       't', item->title, 'n', str_no, 'x', ext, 'i', str_index, 0);
 
 	snprintf(path, path_len, "%s/%s", buf, track);
 	return 0;
@@ -1029,7 +1030,7 @@ export_dialog_response(GtkDialog * dialog, gint response_id, gpointer ex) {
 		int ret;
 		char buf[MAXLEN];
 		char * format = (char *)gtk_entry_get_text(GTK_ENTRY(export->templ_entry));
-		if ((ret = make_string_va(buf, format,
+		if ((ret = make_string_va(buf, CHAR_ARRAY_SIZE(buf), format,
 					  'o', "o", 'a', "a", 'r', "r", 't', "t", 'n', "n", 'x', "x", 'i', "i", 0)) != 0) {
 			make_string_strerror(ret, buf, CHAR_ARRAY_SIZE(buf));
 			message_dialog(_("Error in format string"),

--- a/src/ext_lua.c
+++ b/src/ext_lua.c
@@ -69,7 +69,6 @@ static GtkWidget * l_playlist_menu_sep = NULL;
 static GtkWidget * l_playlist_menu_reload = NULL;
 static GMutex l_mutex;
 static const char l_cur_fdec = 'l';
-static const char l_cur_menu = 'm';
 static const char AQUALUNG_LUA_MAIN_TABLE[] = "Aqualung";
 static const char AQUALUNG_LUA_API[] = "-- AQUALUNG_LUA_API \n\
 Aqualung = {raw_playlist_menu={}, has_playlist_menu=false, \n\

--- a/src/ext_lua.c
+++ b/src/ext_lua.c
@@ -402,7 +402,7 @@ static int l_add_playlist_menu_command(lua_State * L) {
 	/* Copy the string to a Lua userdata for a constant valid address and automatic cleanup */
 	num_chars = strlen(path);
 	lua_path = lua_newuserdata(L, num_chars + 1);
-	strncpy(lua_path, path, num_chars);
+	g_strlcpy(lua_path, path, num_chars + 1);
 
 	entry = gtk_menu_item_new_with_label(name);
 	gtk_menu_shell_append(GTK_MENU_SHELL(menu), entry);

--- a/src/file_info.c
+++ b/src/file_info.c
@@ -649,7 +649,7 @@ save_pic_button_pressed(GtkWidget * widget, gpointer data) {
 			      GTK_FILE_CHOOSER_ACTION_SAVE,
 			      FILE_CHOOSER_FILTER_NONE,
 			      FALSE,
-			      filename);
+			      filename, CHAR_ARRAY_SIZE(filename));
 
 	if (lfiles != NULL) {
 
@@ -779,7 +779,7 @@ change_pic_button_pressed(GtkWidget * widget, gpointer data) {
 			      GTK_FILE_CHOOSER_ACTION_OPEN,
 			      FILE_CHOOSER_FILTER_NONE,
 			      FALSE,
-			      options.currdir);
+			      options.currdir, CHAR_ARRAY_SIZE(options.currdir));
 
 	if (lfiles != NULL) {
 		g_slist_free(lfiles);

--- a/src/file_info.c
+++ b/src/file_info.c
@@ -2205,7 +2205,6 @@ module_info_fill_page(fi_t * fi, meta_frame_t * frame, GtkWidget * vbox) {
 	gint i, n;
 	gchar temp[MAXLEN];
 	GtkWidget *table;
-	GtkWidget *label;
 	GtkWidget *mod_type_label;
 	GtkWidget *mod_channels_label;
 	GtkWidget *mod_patterns_label;

--- a/src/file_info.c
+++ b/src/file_info.c
@@ -1826,7 +1826,7 @@ fi_set_common_entries(fi_t * fi) {
 	}
 	gtk_entry_set_text(GTK_ENTRY(fi->entry_length), str);
 
-	sprintf(str, _("%ld Hz"), fi->fileinfo.sample_rate);
+	arr_snprintf(str, _("%ld Hz"), fi->fileinfo.sample_rate);
 	gtk_entry_set_text(GTK_ENTRY(fi->entry_sr), str);
 
 	if (fi->fileinfo.is_mono) {
@@ -1846,7 +1846,7 @@ fi_set_common_entries(fi_t * fi) {
 	if (fi->fileinfo.total_samples == 0) {
 		strcpy(str, "N/A");
 	} else {
-		sprintf(str, "%lld", fi->fileinfo.total_samples);
+		arr_snprintf(str, "%lld", fi->fileinfo.total_samples);
 	}
 	gtk_entry_set_text(GTK_ENTRY(fi->entry_nsamples), str);
 
@@ -2141,7 +2141,7 @@ show_list(fi_t * fi, gint type) {
                                 ModPlug_SampleName(md_pd->mpf, i, temp);
                         }
 
-                        sprintf(number, "%2d", i);
+                        arr_snprintf(number, "%2d", i);
                         gtk_tree_model_iter_nth_child(GTK_TREE_MODEL(fi->smp_instr_list_store), &iter, NULL, i);
                         gtk_list_store_append(fi->smp_instr_list_store, &iter);
                         gtk_list_store_set(fi->smp_instr_list_store, &iter, 0, number, 1, temp, -1);
@@ -2244,7 +2244,7 @@ module_info_fill_page(fi_t * fi, meta_frame_t * frame, GtkWidget * vbox) {
 		module_info_add_row(_("Samples:"), &mod_samples_label, table, 3);
 		module_info_add_row(_("Instruments:"), &mod_instruments_label, table, 4);
 
-                sprintf(temp, "%d", mdi->instruments);
+                arr_snprintf(temp, "%d", mdi->instruments);
                 gtk_label_set_text (GTK_LABEL(mod_instruments_label), temp);
 
                 table = gtk_table_new (2, 1, FALSE);
@@ -2290,11 +2290,11 @@ module_info_fill_page(fi_t * fi, meta_frame_t * frame, GtkWidget * vbox) {
         }
 
         gtk_label_set_text (GTK_LABEL(mod_type_label), a_type[i]);
-        sprintf(temp, "%d", mdi->channels);
+        arr_snprintf(temp, "%d", mdi->channels);
         gtk_label_set_text (GTK_LABEL(mod_channels_label), temp);
-        sprintf(temp, "%d", mdi->patterns);
+        arr_snprintf(temp, "%d", mdi->patterns);
         gtk_label_set_text (GTK_LABEL(mod_patterns_label), temp);
-        sprintf(temp, "%d", mdi->samples);
+        arr_snprintf(temp, "%d", mdi->samples);
         gtk_label_set_text (GTK_LABEL(mod_samples_label), temp);
 
         vseparator = gtk_vseparator_new ();

--- a/src/file_info.c
+++ b/src/file_info.c
@@ -416,10 +416,10 @@ fi_set_frame_from_source(fi_t * fi, meta_frame_t * frame) {
 		const char * str = gtk_entry_get_text(GTK_ENTRY(frame->source));
 		if (sscanf(str, parsefmt, &val) < 1) {
 			char msg[MAXLEN];
-			snprintf(msg, MAXLEN-1,
-				 _("Conversion error in field %s:\n"
-				   "'%s' does not conform to format '%s'!"),
-				 frame->field_name, str, "%s");
+			arr_snprintf(msg,
+				     _("Conversion error in field %s:\n"
+				       "'%s' does not conform to format '%s'!"),
+				     frame->field_name, str, "%s");
 			message_dialog(_("Error"),
 				       fi->info_window, GTK_MESSAGE_ERROR,
 				       GTK_BUTTONS_OK, NULL, msg, parsefmt_esc);
@@ -432,10 +432,10 @@ fi_set_frame_from_source(fi_t * fi, meta_frame_t * frame) {
 		const char * str = gtk_entry_get_text(GTK_ENTRY(frame->source));
 		if (sscanf(str, parsefmt, &val) < 1) {
 			char msg[MAXLEN];
-			snprintf(msg, MAXLEN-1,
-				 _("Conversion error in field %s:\n"
-				   "'%s' does not conform to format '%s'!"),
-				 frame->field_name, str, "%s");
+			arr_snprintf(msg,
+				     _("Conversion error in field %s:\n"
+				       "'%s' does not conform to format '%s'!"),
+				     frame->field_name, str, "%s");
 			message_dialog(_("Error"),
 				       fi->info_window, GTK_MESSAGE_ERROR,
 				       GTK_BUTTONS_OK, NULL, msg, parsefmt_esc);
@@ -552,10 +552,10 @@ import_button_pressed(GtkWidget * widget, gpointer gptr_data) {
 		gtk_tree_model_get(GTK_TREE_MODEL(music_store), &record_iter, MS_COL_DATA, &record_data, -1);
 		if (sscanf(frame->field_val, "%d", &record_data->year) < 1) {
 			char msg[MAXLEN];
-			snprintf(msg, MAXLEN-1,
-				 _("Error converting field %s to Year:\n"
-				   "'%s' is not an integer number!"),
-				 frame->field_name, frame->field_val);
+			arr_snprintf(msg,
+				     _("Error converting field %s to Year:\n"
+				       "'%s' is not an integer number!"),
+				     frame->field_name, frame->field_val);
 			message_dialog(_("Error"),
 				       fi->info_window, GTK_MESSAGE_ERROR,
 				       GTK_BUTTONS_OK, NULL, msg);
@@ -565,7 +565,7 @@ import_button_pressed(GtkWidget * widget, gpointer gptr_data) {
 		}
 		break;
 	case IMPORT_DEST_NUMBER:
-		snprintf(tmp, MAXLEN-1, "%02d", frame->int_val);
+		arr_snprintf(tmp, "%02d", frame->int_val);
 		gtk_tree_store_set(music_store, &iter_track, MS_COL_SORT, tmp, -1);
 		music_store_mark_changed(&iter_track);
 		break;
@@ -641,7 +641,7 @@ save_pic_button_pressed(GtkWidget * widget, gpointer data) {
 	char * dirname;
 
 	dirname = g_path_get_dirname(options.currdir);
-	snprintf(filename, MAXLEN-1, "%s/%s", dirname, save_pic->savefile);
+	arr_snprintf(filename, "%s/%s", dirname, save_pic->savefile);
 	g_free(dirname);
 
 	lfiles = file_chooser(_("Please specify the file to save the image to."),
@@ -790,7 +790,7 @@ change_pic_button_pressed(GtkWidget * widget, gpointer data) {
 	pformat = gdk_pixbuf_get_file_info(options.currdir, NULL, NULL);
 	if (pformat == NULL) {
 		char msg[MAXLEN];
-		snprintf(msg, MAXLEN-1, _("Could not load image from:\n%s"), options.currdir);
+		arr_snprintf(msg, _("Could not load image from:\n%s"), options.currdir);
 		message_dialog(_("Error"), fi->info_window, GTK_MESSAGE_ERROR,
 			       GTK_BUTTONS_OK, NULL, msg);
 		return;
@@ -823,7 +823,7 @@ change_pic_button_pressed(GtkWidget * widget, gpointer data) {
 	source->image = make_image_from_binary(frame);
 	gtk_widget_show(source->image);
 	gtk_container_add(GTK_CONTAINER(vbox), source->image);
-	snprintf(str, MAXLEN-1, _("MIME type: %s"), frame->field_name);
+	arr_snprintf(str, _("MIME type: %s"), frame->field_name);
 	gtk_label_set_text(GTK_LABEL(source->mime_label), str);
 	/* update callback data for 'Save picture' */
 	save_pic_update(save_pic, fi, frame);
@@ -870,7 +870,7 @@ fi_procframe_label_apic(fi_t * fi, meta_frame_t * frame) {
 	source = ((apic_source_t *)(frame->source));
 
 	meta_get_fieldname(META_FIELD_APIC, &pic_caption);
-	snprintf(str, MAXLEN-1, "%s:", pic_caption);
+	arr_snprintf(str, "%s:", pic_caption);
 
 	label_frame = gtk_frame_new(pic_caption);
 	gtk_container_add(GTK_CONTAINER(label_frame), vbox);
@@ -879,7 +879,7 @@ fi_procframe_label_apic(fi_t * fi, meta_frame_t * frame) {
 
 	hbox = gtk_hbox_new(FALSE, 0);
 	gtk_box_pack_start(GTK_BOX(vbox), hbox, FALSE, FALSE, 3);
-	snprintf(str, MAXLEN-1, _("MIME type: %s"), frame->field_name);
+	arr_snprintf(str, _("MIME type: %s"), frame->field_name);
 	source->mime_label = gtk_label_new(str);
 	gtk_box_pack_start(GTK_BOX(hbox), source->mime_label, FALSE, FALSE, 0);
 
@@ -907,8 +907,8 @@ fi_procframe_label_apic(fi_t * fi, meta_frame_t * frame) {
 	} else {
 		hbox = gtk_hbox_new(FALSE, 0);
 		gtk_box_pack_start(GTK_BOX(vbox), hbox, FALSE, FALSE, 3);
-		snprintf(str, MAXLEN-1, "%s",
-			 meta_id3v2_apic_type_to_string(frame->int_val));
+		arr_snprintf(str, "%s",
+			     meta_id3v2_apic_type_to_string(frame->int_val));
 		label = gtk_label_new(str);
 		gtk_box_pack_start(GTK_BOX(hbox), label, FALSE, FALSE, 0);
 	}
@@ -967,7 +967,7 @@ fi_procframe_label(fi_t * fi, meta_frame_t * frame) {
 		char str[MAXLEN];
 		GtkWidget * hbox = gtk_hbox_new(FALSE, 0);
 		GtkWidget * label;
-		snprintf(str, MAXLEN-1, "%s:", frame->field_name);
+		arr_snprintf(str, "%s:", frame->field_name);
 		label = gtk_label_new(str);
 		gtk_box_pack_start(GTK_BOX(hbox), label, FALSE, FALSE, 0);
 		return hbox;
@@ -1068,13 +1068,13 @@ fi_procframe_entry(fi_t * fi, meta_frame_t * frame) {
 		char str[MAXLEN];
 		char * format = meta_get_field_renderfmt(frame->type);
 		widget = entry = gtk_entry_new();
-		snprintf(str, MAXLEN-1, format, frame->int_val);
+		arr_snprintf(str, format, frame->int_val);
 		gtk_entry_set_text(GTK_ENTRY(entry), str);
 	} else if (META_FIELD_FLOAT(frame->type)) {
 		char str[MAXLEN];
 		char * format = meta_get_field_renderfmt(frame->type);
 		widget = entry = gtk_entry_new();
-		snprintf(str, MAXLEN-1, format, frame->float_val);
+		arr_snprintf(str, format, frame->float_val);
 		gtk_entry_set_text(GTK_ENTRY(entry), str);
 	} else {
 		if (meta->writable && (frame->type == META_FIELD_GENRE)) {

--- a/src/file_info.c
+++ b/src/file_info.c
@@ -573,12 +573,12 @@ import_button_pressed(GtkWidget * widget, gpointer gptr_data) {
 		gtk_tree_model_get(model, &iter_track, MS_COL_DATA, &track_data, -1);
 		tmp[0] = '\0';
 		if (track_data->comment != NULL) {
-			strncat(tmp, track_data->comment, MAXLEN-1);
+			arr_strlcat(tmp, track_data->comment);
 		}
 		if ((tmp[strlen(tmp)-1] != '\n') && (tmp[0] != '\0')) {
-			strncat(tmp, "\n", MAXLEN-1);
+			arr_strlcat(tmp, "\n");
 		}
-		strncat(tmp, frame->field_val, MAXLEN-1);
+		arr_strlcat(tmp, frame->field_val);
 		free_strdup(&track_data->comment, tmp);
 		music_store_mark_changed(&iter_track);
 		break;
@@ -691,7 +691,7 @@ save_pic_update(save_pic_t * save_pic, fi_t * fi, meta_frame_t * frame) {
 	if (mtype[0] == '\0') {
 		strcpy(mtype, "dat");
 	}
-	strncat(savefilename, mtype, 255);
+	arr_strlcat(savefilename, mtype);
 
 	save_pic->fi = fi;
 	strncpy(save_pic->savefile, savefilename, MAXLEN-1);

--- a/src/file_info.c
+++ b/src/file_info.c
@@ -667,7 +667,7 @@ save_pic_button_pressed(GtkWidget * widget, gpointer data) {
 		}
 		fclose(f);
 
-		strncpy(options.currdir, filename, MAXLEN-1);
+		arr_strlcpy(options.currdir, filename);
 	}
 }
 
@@ -680,21 +680,21 @@ save_pic_update(save_pic_t * save_pic, fi_t * fi, meta_frame_t * frame) {
 	char savefilename[256];
 
 	mtype[0] = '\0';
-	strcpy(savefilename, "picture.");
+	arr_strlcpy(savefilename, "picture.");
 	r = sscanf(frame->field_name, "image/%s", mtype);
 	if (r == 0) {
-		strncpy(mtype, frame->field_name, 19);
+		arr_strlcpy(mtype, frame->field_name);
 	}
 	for (i = 0; mtype[i] != '\0'; i++) {
 		mtype[i] = tolower(mtype[i]);
 	}
 	if (mtype[0] == '\0') {
-		strcpy(mtype, "dat");
+		arr_strlcpy(mtype, "dat");
 	}
 	arr_strlcat(savefilename, mtype);
 
 	save_pic->fi = fi;
-	strncpy(save_pic->savefile, savefilename, MAXLEN-1);
+	arr_strlcpy(save_pic->savefile, savefilename);
 	save_pic->image_size = frame->length;
 	save_pic->image_data = frame->data;
 
@@ -1856,11 +1856,11 @@ fi_set_common_entries(fi_t * fi) {
 		int mode = WavpackGetMode(pd->wpc);
 
 		if ((mode & MODE_LOSSLESS) && (mode & MODE_WVC)) {
-			strncpy(str, "Hybrid Lossless", MAXLEN-1);
+			arr_strlcpy(str, "Hybrid Lossless");
 		} else if (mode & MODE_LOSSLESS) {
-			strncpy(str, "Lossless", MAXLEN-1);
+			arr_strlcpy(str, "Lossless");
 		} else {
-			strncpy(str, "Hybrid Lossy", MAXLEN-1);
+			arr_strlcpy(str, "Hybrid Lossy");
 		}
 		cut_trailing_whitespace(str);
 		gtk_entry_set_text(GTK_ENTRY(fi->entry_mode), str);

--- a/src/file_info.c
+++ b/src/file_info.c
@@ -1102,7 +1102,7 @@ fi_procframe_entry(fi_t * fi, meta_frame_t * frame) {
 
 
 import_data_t *
-make_import_data_from_frame(fi_t * fi, meta_frame_t * frame, char * label) {
+make_import_data_from_frame(fi_t * fi, meta_frame_t * frame, char * label, size_t label_size) {
 
 	import_data_t * data = import_data_new();
 	trashlist_add(fi->trash, data);
@@ -1112,33 +1112,33 @@ make_import_data_from_frame(fi_t * fi, meta_frame_t * frame, char * label) {
 	switch (frame->type) {
 	case META_FIELD_TITLE:
 		data->dest_type = IMPORT_DEST_TITLE;
-		strcpy(label, _("Import as Title"));
+		g_strlcpy(label, _("Import as Title"), label_size);
 		break;
 	case META_FIELD_ARTIST:
 		data->dest_type = IMPORT_DEST_ARTIST;
-		strcpy(label, _("Import as Artist"));
+		g_strlcpy(label, _("Import as Artist"), label_size);
 		break;
 	case META_FIELD_ALBUM:
 		data->dest_type = IMPORT_DEST_RECORD;
-		strcpy(label, _("Import as Record"));
+		g_strlcpy(label, _("Import as Record"), label_size);
 		break;
 	case META_FIELD_DATE:
 		data->dest_type = IMPORT_DEST_YEAR;
-		strcpy(label, _("Import as Year"));
+		g_strlcpy(label, _("Import as Year"), label_size);
 		break;
 	case META_FIELD_TRACKNO:
 		data->dest_type = IMPORT_DEST_NUMBER;
-		strcpy(label, _("Import as Track No."));
+		g_strlcpy(label, _("Import as Track No."), label_size);
 		break;
 	case META_FIELD_RG_TRACK_GAIN:
 	case META_FIELD_RG_ALBUM_GAIN:
 	case META_FIELD_RVA2:
 		data->dest_type = IMPORT_DEST_RVA;
-		strcpy(label, _("Import as RVA"));
+		g_strlcpy(label, _("Import as RVA"), label_size);
 		break;
 	default:
 		data->dest_type = IMPORT_DEST_COMMENT;
-		strcpy(label, _("Add to Comments"));
+		g_strlcpy(label, _("Add to Comments"), label_size);
 		break;
 	}
 
@@ -1153,7 +1153,7 @@ fi_procframe_importbtn(fi_t * fi, meta_frame_t * frame) {
 	GtkWidget * button = gtk_button_new();
 	g_signal_connect(G_OBJECT(button), "clicked",
 			 G_CALLBACK(import_button_pressed),
-			 (gpointer)make_import_data_from_frame(fi, frame, label));
+			 (gpointer)make_import_data_from_frame(fi, frame, label, CHAR_ARRAY_SIZE(label)));
 	gtk_button_set_label(GTK_BUTTON(button), label);
 	return button;
 }

--- a/src/file_info.c
+++ b/src/file_info.c
@@ -1839,7 +1839,7 @@ fi_set_common_entries(fi_t * fi) {
 	if (fi->fileinfo.bps == 0) {
 		strcpy(str, "N/A kbit/s");
 	} else {
-		format_bps_label(fi->fileinfo.bps, fi->fileinfo.format_flags, str);
+		format_bps_label(fi->fileinfo.bps, fi->fileinfo.format_flags, str, CHAR_ARRAY_SIZE(str));
 	}
 	gtk_entry_set_text(GTK_ENTRY(fi->entry_bw), str);
 

--- a/src/file_info.c
+++ b/src/file_info.c
@@ -1820,7 +1820,7 @@ fi_set_common_entries(fi_t * fi) {
 	gtk_entry_set_text(GTK_ENTRY(fi->entry_format), fi->fileinfo.format_str);
 
 	if (fi->fileinfo.total_samples == 0) {
-		strcpy(str, "N/A");
+		arr_strlcpy(str, "N/A");
 	} else {
 		sample2time(fi->fileinfo.sample_rate, fi->fileinfo.total_samples, str, CHAR_ARRAY_SIZE(str), 0);
 	}
@@ -1830,21 +1830,21 @@ fi_set_common_entries(fi_t * fi) {
 	gtk_entry_set_text(GTK_ENTRY(fi->entry_sr), str);
 
 	if (fi->fileinfo.is_mono) {
-		strcpy(str, _("MONO"));
+		arr_strlcpy(str, _("MONO"));
 	} else {
-		strcpy(str, _("STEREO"));
+		arr_strlcpy(str, _("STEREO"));
 	}
 	gtk_entry_set_text(GTK_ENTRY(fi->entry_ch), str);
 
 	if (fi->fileinfo.bps == 0) {
-		strcpy(str, "N/A kbit/s");
+		arr_strlcpy(str, "N/A kbit/s");
 	} else {
 		format_bps_label(fi->fileinfo.bps, fi->fileinfo.format_flags, str, CHAR_ARRAY_SIZE(str));
 	}
 	gtk_entry_set_text(GTK_ENTRY(fi->entry_bw), str);
 
 	if (fi->fileinfo.total_samples == 0) {
-		strcpy(str, "N/A");
+		arr_strlcpy(str, "N/A");
 	} else {
 		arr_snprintf(str, "%lld", fi->fileinfo.total_samples);
 	}

--- a/src/file_info.c
+++ b/src/file_info.c
@@ -1822,7 +1822,7 @@ fi_set_common_entries(fi_t * fi) {
 	if (fi->fileinfo.total_samples == 0) {
 		strcpy(str, "N/A");
 	} else {
-		sample2time(fi->fileinfo.sample_rate, fi->fileinfo.total_samples, str, 0);
+		sample2time(fi->fileinfo.sample_rate, fi->fileinfo.total_samples, str, CHAR_ARRAY_SIZE(str), 0);
 	}
 	gtk_entry_set_text(GTK_ENTRY(fi->entry_length), str);
 

--- a/src/gui_main.c
+++ b/src/gui_main.c
@@ -655,7 +655,7 @@ refresh_displays(void) {
 
 		if (!httpc_is_url(pldata->file) && !options.use_ext_title_format) {
 			char list_str[MAXLEN];
-			playlist_data_get_display_name(list_str, pldata);
+			playlist_data_get_display_name(list_str, CHAR_ARRAY_SIZE(list_str), pldata);
 			set_title_label(list_str);
 		} else if (!is_file_loaded) {
 			char * name;

--- a/src/gui_main.c
+++ b/src/gui_main.c
@@ -4103,7 +4103,7 @@ timeout_callback(gpointer data) {
 
 	/* receive and execute remote commands, if any */
 	rcv_count = 0;
-	while (((rcmd = receive_message(aqualung_socket_fd, cmdbuf)) != 0) && (rcv_count < MAX_RCV_COUNT)) {
+	while (((rcmd = receive_message(aqualung_socket_fd, cmdbuf, CHAR_ARRAY_SIZE(cmdbuf))) != 0) && (rcv_count < MAX_RCV_COUNT)) {
 		switch (rcmd) {
 		case RCMD_BACK:
 			prev_event(NULL, NULL, NULL);

--- a/src/gui_main.c
+++ b/src/gui_main.c
@@ -362,13 +362,13 @@ set_title_label(char * str) {
 		gtk_label_set_text(GTK_LABEL(label_title), str);
 		if (options.show_sn_title) {
 			if (stop_after_current_song) {
-				strncat(tmp, "[", MAXLEN-1);
-				strncat(tmp, _("STOPPING"), MAXLEN-1);
-				strncat(tmp, "] ", MAXLEN-1);
+				arr_strlcat(tmp, "[");
+				arr_strlcat(tmp, _("STOPPING"));
+				arr_strlcat(tmp, "] ");
 			}
-			strncat(tmp, str, MAXLEN-1);
-			strncat(tmp, " - ", MAXLEN-1);
-			strncat(tmp, win_title, MAXLEN-1);
+			arr_strlcat(tmp, str);
+			arr_strlcat(tmp, " - ");
+			arr_strlcat(tmp, win_title);
 			gtk_window_set_title(GTK_WINDOW(main_window), tmp);
 #ifdef HAVE_SYSTRAY
 			if (systray_used) {

--- a/src/gui_main.c
+++ b/src/gui_main.c
@@ -532,9 +532,9 @@ set_src_type_label(int src_type) {
 
 	strcpy(str, _("SRC Type: "));
 #ifdef HAVE_SRC
-	strcat(str, src_get_name(src_type));
+	arr_strlcat(str, src_get_name(src_type));
 #else
-	strcat(str, _("None"));
+	arr_strlcat(str, _("None"));
 #endif /* HAVE_SRC */
 
 	gtk_label_set_text(GTK_LABEL(label_src_type), str);
@@ -2558,13 +2558,13 @@ set_win_title(void) {
 	strcpy(win_title, "Aqualung");
 	if (aqualung_session_id > 0) {
 		arr_snprintf(str_session_id, ".%d", aqualung_session_id);
-		strcat(win_title, str_session_id);
+		arr_strlcat(win_title, str_session_id);
 	}
 #ifdef HAVE_JACK
 	if ((output == JACK_DRIVER) && (strcmp(client_name, "aqualung") != 0)) {
-		strcat(win_title, " [");
-		strcat(win_title, client_name);
-		strcat(win_title, "]");
+		arr_strlcat(win_title, " [");
+		arr_strlcat(win_title, client_name);
+		arr_strlcat(win_title, "]");
 	}
 #endif /* HAVE_JACK */
 }

--- a/src/gui_main.c
+++ b/src/gui_main.c
@@ -384,7 +384,7 @@ set_title_label(char * str) {
 #endif /* HAVE_SYSTRAY */
 		}
 	} else {
-		sprintf(default_title, "Aqualung %s", AQUALUNG_VERSION);
+		arr_snprintf(default_title, "Aqualung %s", AQUALUNG_VERSION);
 		gtk_label_set_text(GTK_LABEL(label_title), default_title);
 		gtk_window_set_title(GTK_WINDOW(main_window), win_title);
 #ifdef HAVE_SYSTRAY
@@ -2501,34 +2501,34 @@ main_buttons_set_content(char * skin_path) {
 
 	char path[MAXLEN];
 
-	sprintf(path, "%s/%s", skin_path, "prev.png");
+	arr_snprintf(path, "%s/%s", skin_path, "prev.png");
 	button_set_content(prev_button, path, "prev");
-	sprintf(path, "%s/%s", skin_path, "stop.png");
+	arr_snprintf(path, "%s/%s", skin_path, "stop.png");
 	button_set_content(stop_button, path, "stop");
-	sprintf(path, "%s/%s", skin_path, "next.png");
+	arr_snprintf(path, "%s/%s", skin_path, "next.png");
 	button_set_content(next_button, path, "next");
 	if (options.combine_play_pause) {
-		sprintf(path, "%s/%s", skin_path, "play_pause.png");
+		arr_snprintf(path, "%s/%s", skin_path, "play_pause.png");
 		button_set_content(play_button, path, "play/pause");
 	} else {
-		sprintf(path, "%s/%s", skin_path, "play.png");
+		arr_snprintf(path, "%s/%s", skin_path, "play.png");
 		button_set_content(play_button, path, "play");
-		sprintf(path, "%s/%s", skin_path, "pause.png");
+		arr_snprintf(path, "%s/%s", skin_path, "pause.png");
 		button_set_content(pause_button, path, "pause");
 	}
-	sprintf(path, "%s/%s", skin_path, "repeat.png");
+	arr_snprintf(path, "%s/%s", skin_path, "repeat.png");
 	button_set_content(repeat_button, path, "repeat");
-	sprintf(path, "%s/%s", skin_path, "repeat_all.png");
+	arr_snprintf(path, "%s/%s", skin_path, "repeat_all.png");
 	button_set_content(repeat_all_button, path, "rep_all");
-	sprintf(path, "%s/%s", skin_path, "shuffle.png");
+	arr_snprintf(path, "%s/%s", skin_path, "shuffle.png");
 	button_set_content(shuffle_button, path, "shuffle");
 
-	sprintf(path, "%s/%s", skin_path, "pl.png");
+	arr_snprintf(path, "%s/%s", skin_path, "pl.png");
 	button_set_content(playlist_toggle, path, "PL");
-	sprintf(path, "%s/%s", skin_path, "ms.png");
+	arr_snprintf(path, "%s/%s", skin_path, "ms.png");
 	button_set_content(musicstore_toggle, path, "MS");
 #ifdef HAVE_LADSPA
-	sprintf(path, "%s/%s", skin_path, "fx.png");
+	arr_snprintf(path, "%s/%s", skin_path, "fx.png");
 	button_set_content(plugin_toggle, path, "FX");
 #endif /* HAVE_LADSPA */
 }
@@ -2557,7 +2557,7 @@ set_win_title(void) {
 
 	strcpy(win_title, "Aqualung");
 	if (aqualung_session_id > 0) {
-		sprintf(str_session_id, ".%d", aqualung_session_id);
+		arr_snprintf(str_session_id, ".%d", aqualung_session_id);
 		strcat(win_title, str_session_id);
 	}
 #ifdef HAVE_JACK
@@ -3150,7 +3150,7 @@ create_main_window(char * skin_path) {
 	gtk_box_pack_end(GTK_BOX(btns_hbox), sr_table, FALSE, FALSE, 3);
 
         if (options.disable_skin_support_settings) {
-	        sprintf(path, "%s/no_skin", AQUALUNG_SKINDIR);
+	        arr_snprintf(path, "%s/no_skin", AQUALUNG_SKINDIR);
 	        main_buttons_set_content(path);
         } else {
 	        main_buttons_set_content(skin_path);
@@ -3452,7 +3452,7 @@ setup_systray(void) {
 	GtkWidget * systray__separator1;
 	GtkWidget * systray__separator2;
 
-	sprintf(path, "%s/icon_64.png", AQUALUNG_DATADIR);
+	arr_snprintf(path, "%s/icon_64.png", AQUALUNG_DATADIR);
 	systray_icon = gtk_status_icon_new_from_file(path);
 
         g_signal_connect_swapped(G_OBJECT(systray_icon), "activate",
@@ -3563,9 +3563,9 @@ create_gui(int argc, char ** argv, int optind, int enqueue,
 	load_config();
 
 	if (options.title_format[0] == '\0')
-		sprintf(options.title_format, "%%a: %%t [%%r]");
+		arr_snprintf(options.title_format, "%%a: %%t [%%r]");
 	if (options.skin[0] == '\0') {
-		sprintf(options.skin, "%s/default", AQUALUNG_SKINDIR);
+		arr_snprintf(options.skin, "%s/default", AQUALUNG_SKINDIR);
 		options.main_pos_x = 280;
 		options.main_pos_y = 30;
 		options.main_size_x = 380;
@@ -3583,7 +3583,7 @@ create_gui(int argc, char ** argv, int optind, int enqueue,
 	}
 
 	if (options.cddb_server[0] == '\0') {
-		sprintf(options.cddb_server, "gnudb.org");
+		arr_snprintf(options.cddb_server, "gnudb.org");
 	}
 
 	if (options.src_type == -1) {
@@ -3591,9 +3591,9 @@ create_gui(int argc, char ** argv, int optind, int enqueue,
 	}
 
         if (options.disable_skin_support_settings) {
-	        sprintf(path, "%s/no_skin/rc", AQUALUNG_SKINDIR);
+	        arr_snprintf(path, "%s/no_skin/rc", AQUALUNG_SKINDIR);
         } else {
-	        sprintf(path, "%s/rc", options.skin);
+	        arr_snprintf(path, "%s/rc", options.skin);
         }
 	gtk_rc_parse(path);
 
@@ -3636,27 +3636,27 @@ create_gui(int argc, char ** argv, int optind, int enqueue,
 
 	options_store_watcher_start();
 
-	sprintf(path, "%s/icon_16.png", AQUALUNG_DATADIR);
+	arr_snprintf(path, "%s/icon_16.png", AQUALUNG_DATADIR);
 	if ((pixbuf = gdk_pixbuf_new_from_file(path, NULL)) != NULL) {
 		glist = g_list_append(glist, gdk_pixbuf_new_from_file(path, NULL));
 	}
 
-	sprintf(path, "%s/icon_24.png", AQUALUNG_DATADIR);
+	arr_snprintf(path, "%s/icon_24.png", AQUALUNG_DATADIR);
 	if ((pixbuf = gdk_pixbuf_new_from_file(path, NULL)) != NULL) {
 		glist = g_list_append(glist, gdk_pixbuf_new_from_file(path, NULL));
 	}
 
-	sprintf(path, "%s/icon_32.png", AQUALUNG_DATADIR);
+	arr_snprintf(path, "%s/icon_32.png", AQUALUNG_DATADIR);
 	if ((pixbuf = gdk_pixbuf_new_from_file(path, NULL)) != NULL) {
 		glist = g_list_append(glist, gdk_pixbuf_new_from_file(path, NULL));
 	}
 
-	sprintf(path, "%s/icon_48.png", AQUALUNG_DATADIR);
+	arr_snprintf(path, "%s/icon_48.png", AQUALUNG_DATADIR);
 	if ((pixbuf = gdk_pixbuf_new_from_file(path, NULL)) != NULL) {
 		glist = g_list_append(glist, gdk_pixbuf_new_from_file(path, NULL));
 	}
 
-	sprintf(path, "%s/icon_64.png", AQUALUNG_DATADIR);
+	arr_snprintf(path, "%s/icon_64.png", AQUALUNG_DATADIR);
 	if ((pixbuf = gdk_pixbuf_new_from_file(path, NULL)) != NULL) {
 		glist = g_list_append(glist, gdk_pixbuf_new_from_file(path, NULL));
 	}

--- a/src/gui_main.c
+++ b/src/gui_main.c
@@ -548,7 +548,7 @@ refresh_time_displays(void) {
 
 	if (is_file_loaded) {
 		if (refresh_time_label || options.time_idx[0] != 0) {
-			sample2time(disp_info.sample_rate, disp_pos, str, 0);
+			sample2time(disp_info.sample_rate, disp_pos, str, CHAR_ARRAY_SIZE(str), 0);
 			gtk_label_set_text(GTK_LABEL(time_labels[0]), str);
 
 		}
@@ -557,7 +557,7 @@ refresh_time_displays(void) {
 			if (disp_samples == 0) {
 				strcpy(str, " N/A ");
 			} else {
-				sample2time(disp_info.sample_rate, disp_samples - disp_pos, str, 1);
+				sample2time(disp_info.sample_rate, disp_samples - disp_pos, str, CHAR_ARRAY_SIZE(str), 1);
 			}
 			gtk_label_set_text(GTK_LABEL(time_labels[1]), str);
 
@@ -567,7 +567,7 @@ refresh_time_displays(void) {
 			if (disp_samples == 0) {
 				strcpy(str, " N/A ");
 			} else {
-				sample2time(disp_info.sample_rate, disp_samples, str, 0);
+				sample2time(disp_info.sample_rate, disp_samples, str, CHAR_ARRAY_SIZE(str), 0);
 			}
 			gtk_label_set_text(GTK_LABEL(time_labels[2]), str);
 
@@ -591,8 +591,8 @@ loop_bar_update_tooltip(void) {
 		if (is_file_loaded) {
 			char start[32];
 			char end[32];
-			sample2time(disp_info.sample_rate, total_samples * options.loop_range_start, start, 0);
-			sample2time(disp_info.sample_rate, total_samples * options.loop_range_end, end, 0);
+			sample2time(disp_info.sample_rate, total_samples * options.loop_range_start, start, CHAR_ARRAY_SIZE(start), 0);
+			sample2time(disp_info.sample_rate, total_samples * options.loop_range_end, end, CHAR_ARRAY_SIZE(end), 0);
 			arr_snprintf(str, _("Loop range: %d-%d%% [%s - %s]"),
 				     (int)(100 * options.loop_range_start),
 				     (int)(100 * options.loop_range_end),

--- a/src/gui_main.c
+++ b/src/gui_main.c
@@ -357,7 +357,7 @@ set_title_label(char * str) {
 
 	if (is_file_loaded) {
 		/* Remember current title. */
-		strncpy(playing_app_title, str, MAXLEN-1);
+		arr_strlcpy(playing_app_title, str);
 
 		gtk_label_set_text(GTK_LABEL(label_title), str);
 		if (options.show_sn_title) {
@@ -516,7 +516,7 @@ set_output_label(int output, int out_SR) {
 		break;
 #endif /* HAVE_WINMM */
 	default:
-		strncpy(str, _("No output"), MAXLEN-1);
+		arr_strlcpy(str, _("No output"));
 		break;
 	}
 
@@ -1655,7 +1655,7 @@ cue_track_for_playback(GtkTreeStore * store, GtkTreeIter * piter, cue_t * cue) {
 	gtk_tree_model_get(GTK_TREE_MODEL(store), piter, PL_COL_DATA, &data, -1);
 	cue->filename = strdup(data->file);
 	cue->voladj = options.rva_is_enabled ? data->voladj : 0.0f;
-	strncpy(current_file, cue->filename, MAXLEN-1);
+	arr_strlcpy(current_file, cue->filename);
 }
 
 
@@ -3858,7 +3858,7 @@ process_metablock(metadata_t * meta) {
 
 	// Abuse artist variable
 	if ((artist = application_title_format(fdec)) != NULL) {
-		strncpy(buf, artist, MAXLEN-1);
+		arr_strlcpy(buf, artist);
 		free(artist);
 		artist = NULL;
 	}
@@ -3878,7 +3878,7 @@ process_metablock(metadata_t * meta) {
 				arr_snprintf(buf, "%s (%s)", tmp, icy_name);
 			}
 		} else if (icy_name != NULL) {
-			strncpy(buf, icy_name, MAXLEN-1);
+			arr_strlcpy(buf, icy_name);
 		}
 	}
 
@@ -3899,7 +3899,7 @@ process_metablock(metadata_t * meta) {
 	if (icy_descr != NULL) {
 		arr_snprintf(buf, "%s (%s)", icy_name, icy_descr);
 	} else {
-		strncpy(buf, icy_name, MAXLEN-1);
+		arr_strlcpy(buf, icy_name);
 	}
 
 	/* set playlist_str for playlist entry */

--- a/src/gui_main.c
+++ b/src/gui_main.c
@@ -530,7 +530,7 @@ set_src_type_label(int src_type) {
 
 	char str[MAXLEN];
 
-	strcpy(str, _("SRC Type: "));
+	arr_strlcpy(str, _("SRC Type: "));
 #ifdef HAVE_SRC
 	arr_strlcat(str, src_get_name(src_type));
 #else
@@ -555,7 +555,7 @@ refresh_time_displays(void) {
 
 		if (refresh_time_label || options.time_idx[0] != 1) {
 			if (disp_samples == 0) {
-				strcpy(str, " N/A ");
+				arr_strlcpy(str, " N/A ");
 			} else {
 				sample2time(disp_info.sample_rate, disp_samples - disp_pos, str, CHAR_ARRAY_SIZE(str), 1);
 			}
@@ -565,7 +565,7 @@ refresh_time_displays(void) {
 
 		if (refresh_time_label || options.time_idx[0] != 2) {
 			if (disp_samples == 0) {
-				strcpy(str, " N/A ");
+				arr_strlcpy(str, " N/A ");
 			} else {
 				sample2time(disp_info.sample_rate, disp_samples, str, CHAR_ARRAY_SIZE(str), 0);
 			}
@@ -2555,7 +2555,7 @@ set_win_title(void) {
 
 	char str_session_id[32];
 
-	strcpy(win_title, "Aqualung");
+	arr_strlcpy(win_title, "Aqualung");
 	if (aqualung_session_id > 0) {
 		arr_snprintf(str_session_id, ".%d", aqualung_session_id);
 		arr_strlcat(win_title, str_session_id);

--- a/src/gui_main.c
+++ b/src/gui_main.c
@@ -415,20 +415,20 @@ set_format_label(char * format_str) {
 
 
 void
-format_bps_label(int bps, int format_flags, char * str) {
+format_bps_label(int bps, int format_flags, char * str, size_t str_size) {
 
 	if (bps == 0) {
-		strcpy(str, "N/A kbit/s");
+		g_strlcpy(str, "N/A kbit/s", str_size);
 		return;
 	}
 
 	if (format_flags & FORMAT_VBR) {
-		sprintf(str, "%.1f kbit/s VBR", bps/1000.0);
+		snprintf(str, str_size, "%.1f kbit/s VBR", bps/1000.0);
 	} else {
 		if (format_flags & FORMAT_UBR) {
-			sprintf(str, "%.1f kbit/s UBR", bps/1000.0);
+			snprintf(str, str_size, "%.1f kbit/s UBR", bps/1000.0);
 		} else {
-			sprintf(str, "%.1f kbit/s", bps/1000.0);
+			snprintf(str, str_size, "%.1f kbit/s", bps/1000.0);
 		}
 	}
 }
@@ -438,7 +438,7 @@ set_bps_label(int bps, int format_flags) {
 
 	char str[MAXLEN];
 
-	format_bps_label(bps, format_flags, str);
+	format_bps_label(bps, format_flags, str, CHAR_ARRAY_SIZE(str));
 
 	if (is_file_loaded) {
 		gtk_label_set_text(GTK_LABEL(label_bps), str);

--- a/src/gui_main.c
+++ b/src/gui_main.c
@@ -3872,7 +3872,8 @@ process_metablock(metadata_t * meta) {
 		if ((artist && !is_all_wspace(artist)) ||
 		    (album && !is_all_wspace(album)) ||
 		    (title && !is_all_wspace(title))) {
-			make_title_string(tmp, options.title_format, artist, album, title);
+			make_title_string(tmp, CHAR_ARRAY_SIZE(tmp), options.title_format,
+					  artist, album, title);
 			if (icy_name != NULL) {
 				arr_snprintf(buf, "%s (%s)", tmp, icy_name);
 			}

--- a/src/gui_main.c
+++ b/src/gui_main.c
@@ -453,7 +453,7 @@ set_samplerate_label(int sr) {
 
 	char str[MAXLEN];
 
-	snprintf(str, MAXLEN-1, "%d Hz", sr);
+	arr_snprintf(str, "%d Hz", sr);
 
 	if (is_file_loaded) {
 		gtk_label_set_text(GTK_LABEL(label_samplerate), str);
@@ -487,32 +487,32 @@ set_output_label(int output, int out_SR) {
 	switch (output) {
 #ifdef HAVE_PULSE
 	case PULSE_DRIVER:
-		snprintf(str, MAXLEN-1, "%s PulseAudio @ %d Hz", _("Output:"), out_SR);
+		arr_snprintf(str, "%s PulseAudio @ %d Hz", _("Output:"), out_SR);
 		break;
 #endif /* HAVE_PULSE */
 #ifdef HAVE_SNDIO
 	case SNDIO_DRIVER:
-		snprintf(str, MAXLEN-1, "%s sndio @ %d Hz", _("Output:"), out_SR);
+		arr_snprintf(str, "%s sndio @ %d Hz", _("Output:"), out_SR);
 		break;
 #endif /* HAVE_SNDIO */
 #ifdef HAVE_OSS
 	case OSS_DRIVER:
-		snprintf(str, MAXLEN-1, "%s OSS @ %d Hz", _("Output:"), out_SR);
+		arr_snprintf(str, "%s OSS @ %d Hz", _("Output:"), out_SR);
 		break;
 #endif /* HAVE_OSS */
 #ifdef HAVE_ALSA
 	case ALSA_DRIVER:
-		snprintf(str, MAXLEN-1, "%s ALSA @ %d Hz", _("Output:"), out_SR);
+		arr_snprintf(str, "%s ALSA @ %d Hz", _("Output:"), out_SR);
 		break;
 #endif /* HAVE_ALSA */
 #ifdef HAVE_JACK
 	case JACK_DRIVER:
-		snprintf(str, MAXLEN-1, "%s JACK @ %d Hz", _("Output:"), out_SR);
+		arr_snprintf(str, "%s JACK @ %d Hz", _("Output:"), out_SR);
 		break;
 #endif /* HAVE_JACK */
 #ifdef HAVE_WINMM
 	case WIN32_DRIVER:
-		snprintf(str, MAXLEN-1, "%s Win32 @ %d Hz", _("Output:"), out_SR);
+		arr_snprintf(str, "%s Win32 @ %d Hz", _("Output:"), out_SR);
 		break;
 #endif /* HAVE_WINMM */
 	default:
@@ -593,14 +593,14 @@ loop_bar_update_tooltip(void) {
 			char end[32];
 			sample2time(disp_info.sample_rate, total_samples * options.loop_range_start, start, 0);
 			sample2time(disp_info.sample_rate, total_samples * options.loop_range_end, end, 0);
-			snprintf(str, MAXLEN-1, _("Loop range: %d-%d%% [%s - %s]"),
-				 (int)(100 * options.loop_range_start),
-				 (int)(100 * options.loop_range_end),
-				 start, end);
+			arr_snprintf(str, _("Loop range: %d-%d%% [%s - %s]"),
+				     (int)(100 * options.loop_range_start),
+				     (int)(100 * options.loop_range_end),
+				     start, end);
 		} else {
-			snprintf(str, MAXLEN-1, _("Loop range: %d-%d%%"),
-				 (int)(100 * options.loop_range_start),
-				 (int)(100 * options.loop_range_end));
+			arr_snprintf(str, _("Loop range: %d-%d%%"),
+				     (int)(100 * options.loop_range_start),
+				     (int)(100 * options.loop_range_end));
 		}
 
                 aqualung_widget_set_tooltip_text(loop_bar, str);
@@ -788,7 +788,7 @@ main_window_close(GtkWidget * widget, GdkEvent * event, gpointer data) {
 	if (options.auto_save_playlist) {
 		char playlist_name[MAXLEN];
 
-		snprintf(playlist_name, MAXLEN-1, "%s/%s", options.confdir, "playlist.xml");
+		arr_snprintf(playlist_name, "%s/%s", options.confdir, "playlist.xml");
 		playlist_save_all(playlist_name);
 	}
 
@@ -1469,7 +1469,7 @@ changed_pos(GtkAdjustment * adj, gpointer data) {
 		int newpos = (int)gtk_adjustment_get_value(adj);
 		if (pos != newpos) {
 			char str[32];
-			snprintf(str, 31, _("Position: %d%%"), newpos);
+			arr_snprintf(str, _("Position: %d%%"), newpos);
 			aqualung_widget_set_tooltip_text(scale_pos, str);
 			pos = newpos;
 		}
@@ -1489,9 +1489,9 @@ scale_vol_button_press_event(GtkWidget * widget, GdkEventButton * event) {
 	}
 
 	if (options.vol < -40.5f) {
-		snprintf(str, 31, _("Mute"));
+		arr_snprintf(str, _("Mute"));
 	} else {
-		snprintf(str, 31, _("%d dB"), (int)options.vol);
+		arr_snprintf(str, _("%d dB"), (int)options.vol);
 	}
 
 	gtk_label_set_text(GTK_LABEL(time_labels[options.time_idx[0]]), str);
@@ -1516,16 +1516,16 @@ changed_vol(GtkAdjustment * adj, gpointer date) {
 	gtk_adjustment_set_value(GTK_ADJUSTMENT(adj_vol), options.vol);
 
         if (options.vol < -40.5f) {
-                snprintf(str, 31, _("Mute"));
+                arr_snprintf(str, _("Mute"));
         } else {
-                snprintf(str, 31, _("%d dB"), (int)options.vol);
+                arr_snprintf(str, _("%d dB"), (int)options.vol);
         }
 
         if (!refresh_time_label) {
 		gtk_label_set_text(GTK_LABEL(time_labels[options.time_idx[0]]), str);
         }
 
-        snprintf(str2, 31, _("Volume: %s"), str);
+        arr_snprintf(str2, _("Volume: %s"), str);
         aqualung_widget_set_tooltip_text(scale_vol, str2);
 }
 
@@ -1553,12 +1553,12 @@ scale_bal_button_press_event(GtkWidget * widget, GdkEventButton * event) {
 
 	if (options.bal != 0.0f) {
 		if (options.bal > 0.0f) {
-			snprintf(str, 31, _("%d%% R"), (int)options.bal);
+			arr_snprintf(str, _("%d%% R"), (int)options.bal);
 		} else {
-			snprintf(str, 31, _("%d%% L"), -1*(int)options.bal);
+			arr_snprintf(str, _("%d%% L"), -1*(int)options.bal);
 		}
 	} else {
-		snprintf(str, 31, _("C"));
+		arr_snprintf(str, _("C"));
 	}
 
 	gtk_label_set_text(GTK_LABEL(time_labels[options.time_idx[0]]), str);
@@ -1584,19 +1584,19 @@ changed_bal(GtkAdjustment * adj, gpointer date) {
 
         if (options.bal != 0.0f) {
                 if (options.bal > 0.0f) {
-                        snprintf(str, 31, _("%d%% R"), (int)options.bal);
+                        arr_snprintf(str, _("%d%% R"), (int)options.bal);
                 } else {
-                        snprintf(str, 31, _("%d%% L"), -1*(int)options.bal);
+                        arr_snprintf(str, _("%d%% L"), -1*(int)options.bal);
                 }
         } else {
-                snprintf(str, 31, _("C"));
+                arr_snprintf(str, _("C"));
         }
 
         if (!refresh_time_label) {
 		gtk_label_set_text(GTK_LABEL(time_labels[options.time_idx[0]]), str);
 	}
 
-        snprintf(str2, 31, _("Balance: %s"), str);
+        arr_snprintf(str2, _("Balance: %s"), str);
         aqualung_widget_set_tooltip_text(scale_bal, str2);
 }
 
@@ -3741,7 +3741,7 @@ create_gui(int argc, char ** argv, int optind, int enqueue,
 		int start_playback = (argv[optind] == NULL) && immediate_start;
 		char file[MAXLEN];
 
-		snprintf(file, MAXLEN-1, "%s/%s", options.confdir, "playlist.xml");
+		arr_snprintf(file, "%s/%s", options.confdir, "playlist.xml");
 		if (g_file_test(file, G_FILE_TEST_EXISTS) == TRUE) {
 			GSList * list = g_slist_append(NULL, strdup(file));
 			playlist_load(list, PLAYLIST_LOAD_TAB, NULL, start_playback);
@@ -3874,7 +3874,7 @@ process_metablock(metadata_t * meta) {
 		    (title && !is_all_wspace(title))) {
 			make_title_string(tmp, options.title_format, artist, album, title);
 			if (icy_name != NULL) {
-				snprintf(buf, MAXLEN-1, "%s (%s)", tmp, icy_name);
+				arr_snprintf(buf, "%s (%s)", tmp, icy_name);
 			}
 		} else if (icy_name != NULL) {
 			strncpy(buf, icy_name, MAXLEN-1);
@@ -3896,7 +3896,7 @@ process_metablock(metadata_t * meta) {
 	metadata_get_icy_descr(meta, &icy_descr);
 
 	if (icy_descr != NULL) {
-		snprintf(buf, MAXLEN-1, "%s (%s)", icy_name, icy_descr);
+		arr_snprintf(buf, "%s (%s)", icy_name, icy_descr);
 	} else {
 		strncpy(buf, icy_name, MAXLEN-1);
 	}

--- a/src/gui_main.h
+++ b/src/gui_main.h
@@ -42,7 +42,7 @@ void create_gui(int argc, char ** argv, int optind, int enqueue,
 
 void run_gui(void);
 
-void format_bps_label(int bps, int format_flags, char * str);
+void format_bps_label(int bps, int format_flags, char * str, size_t str_size);
 
 void refresh_displays(void);
 void main_window_set_font(int cond);

--- a/src/httpc.c
+++ b/src/httpc.c
@@ -372,8 +372,8 @@ parse_http_headers(http_session_t * session) {
 		if (new_name[0] == '\0') {
 			arr_snprintf(value, "%s %s", value, new_value);
 		} else {
-			strcpy(name, new_name);
-			strcpy(value, new_value);
+			arr_strlcpy(name, new_name);
+			arr_strlcpy(value, new_value);
 		}
 		
 		if (strcasecmp(name, "location") == 0) {

--- a/src/httpc.c
+++ b/src/httpc.c
@@ -370,7 +370,8 @@ parse_http_headers(http_session_t * session) {
 			return -3;
 		
 		if (new_name[0] == '\0') {
-			arr_snprintf(value, "%s %s", value, new_value);
+			arr_strlcat(value, " ");
+			arr_strlcat(value, new_value);
 		} else {
 			arr_strlcpy(name, new_name);
 			arr_strlcpy(value, new_value);

--- a/src/httpc.c
+++ b/src/httpc.c
@@ -328,8 +328,8 @@ check_http_response(char * line, char * resp) {
 	char http10[16];
 	char http11[16];
 
-	snprintf(http10, 15, "HTTP/1.0 %s", resp);
-	snprintf(http11, 15, "HTTP/1.1 %s", resp);
+	arr_snprintf(http10, "HTTP/1.0 %s", resp);
+	arr_snprintf(http11, "HTTP/1.1 %s", resp);
 
 	return (strstr(line, http10) != NULL) || (strstr(line, http11) != NULL);
 }
@@ -370,7 +370,7 @@ parse_http_headers(http_session_t * session) {
 			return -3;
 		
 		if (new_name[0] == '\0') {
-			snprintf(value, sizeof(value), "%s %s", value, new_value);
+			arr_snprintf(value, "%s %s", value, new_value);
 		} else {
 			strcpy(name, new_name);
 			strcpy(value, new_value);
@@ -452,7 +452,7 @@ make_http_request_text(char * host, int port, char * path,
 	char extra_header[1024];
 	
 	if (start_byte != 0) {
-		snprintf(extra_header, sizeof(extra_header), "Range: bytes=%lld-\r\n", start_byte);
+		arr_snprintf(extra_header, "Range: bytes=%lld-\r\n", start_byte);
 	} else {
 		extra_header[0] = '\0';
 	}

--- a/src/httpc.c
+++ b/src/httpc.c
@@ -303,19 +303,18 @@ strip_whitespace(char * str) {
 }
 
 int
-parse_field(char * line, char * name, char * value) {
+parse_field(char * line, char * name, size_t name_size, char * value, size_t value_size) {
 	
 	if (line[0] == ' ' || line[0] == '\t') {
 		name[0] = '\0';
-		strcpy(value, strip_whitespace(line));
+		g_strlcpy(value, strip_whitespace(line), value_size);
 	} else {
 		char * c = strstr(line, ":");
 		if (c == NULL)
 			return -1;
-		strncpy(name, line, c-line);
-		name[c-line] = '\0';
-		strncpy(value, c+1, strlen(c)-1);
-		value[strlen(c)-1] = '\0';
+		*c = '\0';
+		g_strlcpy(name, line, name_size);
+		g_strlcpy(value, c + 1, value_size);
 		strip_whitespace(name);
 		strip_whitespace(value);
 	}
@@ -366,7 +365,8 @@ parse_http_headers(http_session_t * session) {
 		if (line[0] == '\0')
 			break;
 		
-		if (parse_field(line, new_name, new_value) == -1)
+		if (parse_field(line, new_name, CHAR_ARRAY_SIZE(new_name),
+				new_value, CHAR_ARRAY_SIZE(new_value)) == -1)
 			return -3;
 		
 		if (new_name[0] == '\0') {

--- a/src/httpc.c
+++ b/src/httpc.c
@@ -595,22 +595,20 @@ httpc_init(http_session_t * session, file_decoder_t * fdec,
 	
 	if ((p = strstr(URL, ":")) != NULL) {
 		unsigned int l = p - URL;
-		if (l > sizeof(host)) {
+		if (l + 1 > sizeof(host)) {
 			return HTTPC_URL_ERROR;
 		}
-		strncpy(host, URL, l);
-		host[l] = '\0';
+		g_strlcpy(host, URL, l + 1);
 		URL += l+1;
 		if ((p = strstr(URL, "/")) != NULL) {
 			unsigned int m = p - URL;
-			if (m > sizeof(port_str)) {
+			if (m + 1 > sizeof(port_str)) {
 				return HTTPC_URL_ERROR;
 			}
-			strncpy(port_str, URL, m);
-			port_str[m] = '\0';
+			g_strlcpy(port_str, URL, m + 1);
 			URL += m;
 		} else {
-			strncpy(port_str, URL, sizeof(port_str));
+			arr_strlcpy(port_str, URL);
 			URL = "/";
 		}
 		if (sscanf(port_str, "%d", &port) != 1) {
@@ -619,15 +617,14 @@ httpc_init(http_session_t * session, file_decoder_t * fdec,
 	} else {
 		if ((p = strstr(URL, "/")) != NULL) {
 			unsigned int l = p - URL;
-			if (l > sizeof(host)) {
+			if (l + 1 > sizeof(host)) {
 				return HTTPC_URL_ERROR;
 			}
-			strncpy(host, URL, l);
-			host[l] = '\0';
+			g_strlcpy(host, URL, l + 1);
 			URL += l;
 			port = 80;      
 		} else {
-			strncpy(host, URL, sizeof(host));
+			arr_strlcpy(host, URL);
 			port = 80;
 			URL = "/";
 		}

--- a/src/ifp_device.c
+++ b/src/ifp_device.c
@@ -117,7 +117,7 @@ update_progress (void *context, struct ifp_transfer_status *status) {
         gchar temp[MAXLEN];
 
         gtk_progress_bar_set_fraction(GTK_PROGRESS_BAR(progressbar_cf), (float)status->file_bytes/status->file_total);
-        sprintf(temp, _("%.1f MB / %.1f MB"), (float)status->file_bytes/(1024*1024), (float)status->file_total/(1024*1024));
+        arr_snprintf(temp, _("%.1f MB / %.1f MB"), (float)status->file_bytes/(1024*1024), (float)status->file_total/(1024*1024));
         gtk_progress_bar_set_text (GTK_PROGRESS_BAR (progressbar_cf), temp);
 
         if (abort_pressed) {
@@ -159,7 +159,7 @@ upload_songs_cb_foreach(playlist_t * pl, GtkTreeIter * iter, void * data) {
 
         gtk_progress_bar_set_fraction(GTK_PROGRESS_BAR(progressbar_op),
                                       (float)(*n + 1) / number_of_songs);
-        sprintf(temp, _("%d / %d files"), *n + 1, number_of_songs);
+        arr_snprintf(temp, _("%d / %d files"), *n + 1, number_of_songs);
         gtk_progress_bar_set_text(GTK_PROGRESS_BAR (progressbar_op), temp);
 
         ifp_upload_file(&ifpdev, pldata->file, dest_file, update_progress, NULL);
@@ -205,11 +205,11 @@ download_songs_cb_foreach (GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *
                                               (float)(*n + 1) / number_of_songs);
 
                 if (ifp_is_file (&ifpdev, remote_item) == TRUE) {
-                        sprintf(temp, _("%d / %d files"), *n + 1, number_of_songs);
+                        arr_snprintf(temp, _("%d / %d files"), *n + 1, number_of_songs);
                         gtk_progress_bar_set_text(GTK_PROGRESS_BAR (progressbar_op), temp);
                         ifp_download_file (&ifpdev, remote_item, dest_file, update_progress, NULL);
                 } else {
-                        sprintf(temp, _("%d / %d directories"), *n + 1, number_of_songs);
+                        arr_snprintf(temp, _("%d / %d directories"), *n + 1, number_of_songs);
                         gtk_progress_bar_set_text(GTK_PROGRESS_BAR (progressbar_op), temp);
                         ifp_download_dir (&ifpdev, remote_item, dest_file, update_progress, NULL);
                 }
@@ -435,11 +435,11 @@ aifp_remove_item_cb (GtkButton *button, gpointer user_data) {
         if (strncmp(remote_item, PARENTDIR, 2)) {
 
                 if (remote_type == TYPE_DIR) {
-                        sprintf(temp, _("Directory '%s' will be removed with its entire contents.\n\nDo you want to proceed?"),
-                                remote_item);
+                        arr_snprintf(temp, _("Directory '%s' will be removed with its entire contents.\n\nDo you want to proceed?"),
+                                     remote_item);
                 } else {
-                        sprintf(temp, _("File '%s' will be removed.\n\nDo you want to proceed?"),
-                                remote_item);
+                        arr_snprintf(temp, _("File '%s' will be removed.\n\nDo you want to proceed?"),
+                                     remote_item);
                 }
 
                 response = message_dialog(_("Remove"), aifp_window, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
@@ -538,7 +538,7 @@ aifp_dump_files(void *context, int type, const char *name, int filesize) {
 
         if (type == IFP_FILE) {
                 gtk_list_store_append(list_store, &iter);
-                sprintf(temp, "%.1f MB", (double)filesize/(1024*1024));
+                arr_snprintf(temp, "%.1f MB", (double)filesize/(1024*1024));
                 gtk_list_store_set(list_store, &iter, 0, name, 1, temp, -1);
         }
 
@@ -605,8 +605,8 @@ aifp_update_info(void) {
         gfloat space;
 
         if (transfer_mode == UPLOAD_MODE) {
-                sprintf(temp, "%d", number_of_songs);
-                sprintf(tmp, _(" (%.1f MB)"), (float)songs_size / (1024*1024));
+                arr_snprintf(temp, "%d", number_of_songs);
+                arr_snprintf(tmp, _(" (%.1f MB)"), (float)songs_size / (1024*1024));
                 arr_strlcat(temp, tmp);
                 gtk_label_set_text(GTK_LABEL(label_songs), temp);
         }
@@ -616,12 +616,12 @@ aifp_update_info(void) {
 
         ifp_model(&ifpdev, temp, sizeof(temp));
         capacity = ifp_capacity(&ifpdev);
-        sprintf(tmp, _(" (capacity = %.1f MB)"), (float)capacity / (1024*1024));
+        arr_snprintf(tmp, _(" (capacity = %.1f MB)"), (float)capacity / (1024*1024));
         arr_strlcat(temp, tmp);
         gtk_label_set_text(GTK_LABEL(label_model), temp);
 
         freespace = ifp_freespace(&ifpdev);
-        sprintf(temp, _(" Free space (%.1f MB)"), (float)freespace / (1024*1024));
+        arr_snprintf(temp, _(" Free space (%.1f MB)"), (float)freespace / (1024*1024));
 
         space = (float)freespace/capacity;
 
@@ -921,15 +921,15 @@ aifp_transfer_files(gint mode) {
                 if (k != number_of_songs) {
                         if (k) {
                                 if((number_of_songs-k) == 1) {
-                                        sprintf(temp, _("One song has format unsupported by your player.\n\nDo you want to proceed?"));
+                                        arr_snprintf(temp, _("One song has format unsupported by your player.\n\nDo you want to proceed?"));
                                 } else {
-                                        sprintf(temp, _("%d of %d songs have format unsupported by your player.\n\nDo you want to proceed?"), number_of_songs-k, number_of_songs);
+                                        arr_snprintf(temp, _("%d of %d songs have format unsupported by your player.\n\nDo you want to proceed?"), number_of_songs-k, number_of_songs);
                                 }
                         } else {
                                 if (number_of_songs == 1) {
-                                        sprintf(temp, _("The selected song has format unsupported by your player.\n\nDo you want to proceed?"));
+                                        arr_snprintf(temp, _("The selected song has format unsupported by your player.\n\nDo you want to proceed?"));
                                 } else {
-                                        sprintf(temp, _("None of the selected songs has format supported by your player.\n\nDo you want to proceed?"));
+                                        arr_snprintf(temp, _("None of the selected songs has format supported by your player.\n\nDo you want to proceed?"));
                                 }
                         }
 

--- a/src/ifp_device.c
+++ b/src/ifp_device.c
@@ -150,9 +150,9 @@ upload_songs_cb_foreach(playlist_t * pl, GtkTreeIter * iter, void * data) {
 
         strncpy(dest_file, remote_path, MAXLEN-1);
         if (strlen(remote_path) != 1) {
-                strncat(dest_file, "\\", MAXLEN-1);
+                arr_strlcat(dest_file, "\\");
         }
-        strncat(dest_file, file, MAXLEN-1);
+        arr_strlcat(dest_file, file);
 
         gtk_entry_set_text(GTK_ENTRY(aifp_file_entry), file);
         gtk_editable_set_position(GTK_EDITABLE(aifp_file_entry), -1);
@@ -190,13 +190,13 @@ download_songs_cb_foreach (GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *
         if (strncmp(file, PARENTDIR, 2)) {
                 strncpy(remote_item, remote_path, MAXLEN-1);
                 if (strlen(remote_path) != 1) {
-                        strncat(remote_item, "\\", MAXLEN-1);
+                        arr_strlcat(remote_item, "\\");
                 }
-                strncat(remote_item, file, MAXLEN-1);
+                arr_strlcat(remote_item, file);
 
                 strncpy(dest_file, dest_dir, MAXLEN-1);
-                strncat(dest_file, "/", MAXLEN-1);
-                strncat(dest_file, file, MAXLEN-1);
+                arr_strlcat(dest_file, "/");
+                arr_strlcat(dest_file, file);
 
                 gtk_entry_set_text(GTK_ENTRY(aifp_file_entry), file);
                 gtk_editable_set_position(GTK_EDITABLE(aifp_file_entry), -1);
@@ -346,9 +346,9 @@ aifp_create_directory_cb (GtkButton *button, gpointer user_data) {
 
                 strncpy(temp, remote_path, MAXLEN-1);
                 if (strlen(remote_path) != 1) {
-                        strncat(temp, "\\", MAXLEN-1);
+                        arr_strlcat(temp, "\\");
                 }
-                strncat(temp, gtk_entry_get_text(GTK_ENTRY(name_entry)), MAXLEN-1);
+                arr_strlcat(temp, gtk_entry_get_text(GTK_ENTRY(name_entry)));
 
                 if (strlen(temp)) {
 
@@ -405,16 +405,16 @@ aifp_rename_item_cb (GtkButton *button, gpointer user_data) {
 
                         strncpy(temp, remote_path, MAXLEN-1);
                         if (strlen(remote_path) != 1) {
-                                strncat(temp, "\\", MAXLEN-1);
+                                arr_strlcat(temp, "\\");
                         }
-                        strncat(temp, text, MAXLEN-1);
+                        arr_strlcat(temp, text);
 
                         if (strlen(text)) {
                                 strncpy(dest_file, remote_path, MAXLEN-1);
                                 if (strlen(remote_path) != 1) {
-                                        strncat(dest_file, "\\", MAXLEN-1);
+                                        arr_strlcat(dest_file, "\\");
                                 }
-                                strncat(dest_file, remote_item, MAXLEN-1);
+                                arr_strlcat(dest_file, remote_item);
 
                                 ifp_rename(&ifpdev, dest_file, temp);
                                 aifp_update_info();
@@ -449,9 +449,9 @@ aifp_remove_item_cb (GtkButton *button, gpointer user_data) {
 
                         strncpy(temp, remote_path, MAXLEN-1);
                         if (strlen(remote_path) != 1) {
-                                strncat(temp, "\\", MAXLEN-1);
+                                arr_strlcat(temp, "\\");
                         }
-                        strncat(temp, remote_item, MAXLEN-1);
+                        arr_strlcat(temp, remote_item);
 
                         if (ifp_is_file (&ifpdev, temp) == TRUE) {
                                 ifp_delete (&ifpdev, temp);
@@ -607,7 +607,7 @@ aifp_update_info(void) {
         if (transfer_mode == UPLOAD_MODE) {
                 sprintf(temp, "%d", number_of_songs);
                 sprintf(tmp, _(" (%.1f MB)"), (float)songs_size / (1024*1024));
-                strncat (temp, tmp, MAXLEN-1);
+                arr_strlcat(temp, tmp);
                 gtk_label_set_text(GTK_LABEL(label_songs), temp);
         }
 
@@ -617,7 +617,7 @@ aifp_update_info(void) {
         ifp_model(&ifpdev, temp, sizeof(temp));
         capacity = ifp_capacity(&ifpdev);
         sprintf(tmp, _(" (capacity = %.1f MB)"), (float)capacity / (1024*1024));
-        strncat (temp, tmp, MAXLEN-1);
+        arr_strlcat(temp, tmp);
         gtk_label_set_text(GTK_LABEL(label_model), temp);
 
         freespace = ifp_freespace(&ifpdev);
@@ -813,7 +813,7 @@ gchar *npath;
                         if (strlen(remote_path) != 1) {
                                 strcat(remote_path, "\\");
                         }
-                        strncat(remote_path, remote_item, MAXLEN-1);
+                        arr_strlcat(remote_path, remote_item);
                         aifp_directory_listing(NULL);
                 }
         }

--- a/src/ifp_device.c
+++ b/src/ifp_device.c
@@ -805,7 +805,7 @@ gchar *npath;
                         if (npath != NULL) {
                                 *npath = '\0';
                                 if (!strlen(remote_path)) {
-                                        strcpy(remote_path, "\\");
+                                        arr_strlcpy(remote_path, "\\");
                                 }
                                 aifp_directory_listing(NULL);
                         }
@@ -899,7 +899,7 @@ aifp_transfer_files(gint mode) {
         transfer_mode = mode;
         songs_size = 0;
         transfer_active = 0;
-        strcpy(remote_path, "\\");
+        arr_strlcpy(remote_path, "\\");
 
         if (transfer_mode == UPLOAD_MODE) {
                 number_of_songs = aifp_get_number_of_songs();

--- a/src/ifp_device.c
+++ b/src/ifp_device.c
@@ -148,7 +148,7 @@ upload_songs_cb_foreach(playlist_t * pl, GtkTreeIter * iter, void * data) {
 
 	file = g_path_get_basename(pldata->file);
 
-        strncpy(dest_file, remote_path, MAXLEN-1);
+        arr_strlcpy(dest_file, remote_path);
         if (strlen(remote_path) != 1) {
                 arr_strlcat(dest_file, "\\");
         }
@@ -188,13 +188,13 @@ download_songs_cb_foreach (GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *
         gtk_tree_model_get (model, iter, COLUMN_NAME, &file, -1);
 
         if (strncmp(file, PARENTDIR, 2)) {
-                strncpy(remote_item, remote_path, MAXLEN-1);
+                arr_strlcpy(remote_item, remote_path);
                 if (strlen(remote_path) != 1) {
                         arr_strlcat(remote_item, "\\");
                 }
                 arr_strlcat(remote_item, file);
 
-                strncpy(dest_file, dest_dir, MAXLEN-1);
+                arr_strlcpy(dest_file, dest_dir);
                 arr_strlcat(dest_file, "/");
                 arr_strlcat(dest_file, file);
 
@@ -344,7 +344,7 @@ aifp_create_directory_cb (GtkButton *button, gpointer user_data) {
 
         if (response == GTK_RESPONSE_OK) {
 
-                strncpy(temp, remote_path, MAXLEN-1);
+                arr_strlcpy(temp, remote_path);
                 if (strlen(remote_path) != 1) {
                         arr_strlcat(temp, "\\");
                 }
@@ -403,14 +403,14 @@ aifp_rename_item_cb (GtkButton *button, gpointer user_data) {
 
                         text = gtk_entry_get_text(GTK_ENTRY(name_entry));
 
-                        strncpy(temp, remote_path, MAXLEN-1);
+                        arr_strlcpy(temp, remote_path);
                         if (strlen(remote_path) != 1) {
                                 arr_strlcat(temp, "\\");
                         }
                         arr_strlcat(temp, text);
 
                         if (strlen(text)) {
-                                strncpy(dest_file, remote_path, MAXLEN-1);
+                                arr_strlcpy(dest_file, remote_path);
                                 if (strlen(remote_path) != 1) {
                                         arr_strlcat(dest_file, "\\");
                                 }
@@ -447,7 +447,7 @@ aifp_remove_item_cb (GtkButton *button, gpointer user_data) {
 
                 if (response == GTK_RESPONSE_YES) {
 
-                        strncpy(temp, remote_path, MAXLEN-1);
+                        arr_strlcpy(temp, remote_path);
                         if (strlen(remote_path) != 1) {
                                 arr_strlcat(temp, "\\");
                         }
@@ -474,7 +474,7 @@ item_selected (GtkTreeModel *model, GtkTreeIter *iter, gpointer data) {
         int * n = (int *)data;
 
         gtk_tree_model_get (model, iter, COLUMN_NAME, &text, COLUMN_TYPE_SIZE, &type, -1);
-        strncpy(remote_item, text, MAXLEN-1);
+        arr_strlcpy(remote_item, text);
 
         remote_type = TYPE_DIR;
 
@@ -855,7 +855,7 @@ directory_chooser(char * title, GtkWidget * parent, char * directory) {
 			gtk_widget_destroy(dialog);
 		}
 
-                strncpy(directory, selected_directory, MAXLEN-1);
+                arr_strlcpy(directory, selected_directory);
 		g_free(utf8);
         }
 
@@ -1185,7 +1185,7 @@ aifp_transfer_files(gint mode) {
                 gtk_widget_set_can_focus(local_path_entry, FALSE);
                 gtk_box_pack_start(GTK_BOX(hbox2), local_path_entry, TRUE, TRUE, 2);
                 gtk_editable_set_editable (GTK_EDITABLE(local_path_entry), FALSE);
-                strncpy(dest_dir, options.home, MAXLEN-1);
+                arr_strlcpy(dest_dir, options.home);
                 gtk_entry_set_text(GTK_ENTRY(local_path_entry), dest_dir);
 
                 local_path_browse_button = gui_stock_label_button(_("Browse"), GTK_STOCK_OPEN);

--- a/src/ifp_device.c
+++ b/src/ifp_device.c
@@ -811,7 +811,7 @@ gchar *npath;
                         }
                 } else {
                         if (strlen(remote_path) != 1) {
-                                strcat(remote_path, "\\");
+                                arr_strlcat(remote_path, "\\");
                         }
                         arr_strlcat(remote_path, remote_item);
                         aifp_directory_listing(NULL);

--- a/src/metadata_ape.c
+++ b/src/metadata_ape.c
@@ -427,8 +427,8 @@ meta_ape_render_bin_frames(metadata_t * meta, ape_tag_t * tag, int type,
 
 		switch (type) {
 		case META_FIELD_APIC:
-			snprintf(key, 254, "Cover Art (%s)",
-				 meta_id3v2_apic_type_to_string(frame->int_val));
+			arr_snprintf(key, "Cover Art (%s)",
+				     meta_id3v2_apic_type_to_string(frame->int_val));
 			strncpy((char *)item->key, key, 255);
 			meta_ape_render_apic(frame, item);
 			break;
@@ -498,11 +498,11 @@ metadata_to_ape_tag(metadata_t * meta, ape_tag_t * tag) {
 				field_val = frame->field_val;
 				field_len = strlen(frame->field_val);
 			} else if (META_FIELD_INT(type)) {
-				snprintf(fval, MAXLEN-1, renderfmt, frame->int_val);
+				arr_snprintf(fval, renderfmt, frame->int_val);
 				field_val = fval;
 				field_len = strlen(field_val);
 			} else if (META_FIELD_FLOAT(type)) {
-				snprintf(fval, MAXLEN-1, renderfmt, frame->float_val);
+				arr_snprintf(fval, renderfmt, frame->float_val);
 				field_val = fval;
 				field_len = strlen(field_val);
 			}

--- a/src/metadata_flac.c
+++ b/src/metadata_flac.c
@@ -118,10 +118,10 @@ meta_entry_from_frame(FLAC__StreamMetadata_VorbisComment_Entry * entry,
 	if (META_FIELD_TEXT(frame->type)) {
 		val = frame->field_val;
 	} else if (META_FIELD_INT(frame->type)) {
-		snprintf(str, MAXLEN-1, renderfmt, frame->int_val);
+		arr_snprintf(str, renderfmt, frame->int_val);
 		val = str;
 	} else if (META_FIELD_FLOAT(frame->type)) {
-		snprintf(str, MAXLEN-1, renderfmt, frame->float_val);
+		arr_snprintf(str, renderfmt, frame->float_val);
 		val = str;
 	} else {
 		fprintf(stderr, "meta_entry_from_frame: frame type 0x%x is unsupported\n", frame->type);

--- a/src/metadata_id3v1.c
+++ b/src/metadata_id3v1.c
@@ -324,7 +324,7 @@ metadata_from_id3v1(metadata_t * meta, unsigned char * buf) {
 	memcpy(raw, buf+97, 30);
 	if ((raw[28] == '\0') && (raw[29] != '\0')) { /* ID3v1.1 */
 		char track[4];
-		snprintf(track, 4, "%u", (unsigned char)raw[29]);
+		arr_snprintf(track, "%u", (unsigned char)raw[29]);
 		meta_add_id3v1_frame(meta, "Track", track);
 	}
 

--- a/src/metadata_id3v2.c
+++ b/src/metadata_id3v2.c
@@ -269,9 +269,9 @@ meta_parse_id3v2_t___(metadata_t * meta, unsigned char * buf, int len) {
 	    (strcmp(frame_id, "TIME") == 0) ||
 	    (strcmp(frame_id, "TRDA") == 0) ||
 	    (strcmp(frame_id, "TYER") == 0)) {
-		strcpy(frame_id, "TDRC");
+		arr_strlcpy(frame_id, "TDRC");
 	} else if (strcmp(frame_id, "TORY") == 0) {
-		strcpy(frame_id, "TDOR");
+		arr_strlcpy(frame_id, "TDOR");
 	}
 
 	val = meta_id3v2_to_utf8(buf[10], buf+11, len-1);

--- a/src/metadata_id3v2.c
+++ b/src/metadata_id3v2.c
@@ -442,7 +442,7 @@ meta_parse_id3v2_rva2(metadata_t * meta, unsigned char * buf, int len) {
 			frame->tag = META_TAG_ID3v2;
 			frame->type = META_FIELD_RVA2;
 			meta_get_fieldname(META_FIELD_RVA2, &field_name);
-			snprintf(str, MAXLEN-1, "%s (%s)", field_name, id);
+			arr_snprintf(str, "%s (%s)", field_name, id);
 			frame->field_name = strdup(str);
 			frame->field_val = strdup(id);
  			frame->float_val = voladj_float;
@@ -673,11 +673,11 @@ meta_render_id3v2_t___(meta_frame_t * frame, unsigned char ** buf, int * size) {
 		field_val = frame->field_val;
 		field_len = strlen(field_val);
 	} else if (META_FIELD_INT(frame->type)) {
-		snprintf(fval, MAXLEN-1, renderfmt, frame->int_val);
+		arr_snprintf(fval, renderfmt, frame->int_val);
 		field_val = fval;
 		field_len = strlen(field_val);
 	} else if (META_FIELD_FLOAT(frame->type)) {
-		snprintf(fval, MAXLEN-1, renderfmt, frame->float_val);
+		arr_snprintf(fval, renderfmt, frame->float_val);
 		field_val = fval;
 		field_len = strlen(field_val);
 	}

--- a/src/metadata_ogg.c
+++ b/src/metadata_ogg.c
@@ -716,6 +716,7 @@ meta_ogg_vc_render(metadata_t * meta, unsigned int * length) {
 	/* all else */
 	frame = metadata_get_frame_by_tag(meta, META_TAG_OXC, NULL);
 	while (frame != NULL) {
+		size_t vc_entry_size;
 		char * vc_entry;
 		int vc_len;
 		int field_len;
@@ -734,12 +735,13 @@ meta_ogg_vc_render(metadata_t * meta, unsigned int * length) {
 			str = frame->field_name;
 		}
 
-		vc_entry = calloc(strlen(str) + 2, 1);
-		strcpy(vc_entry, str);
+		vc_entry_size = strlen(str) + 2;
+		vc_entry = calloc(vc_entry_size, 1);
+		g_strlcpy(vc_entry, str, vc_entry_size);
 		for (i = 0; vc_entry[i] != '\0'; i++) {
 			vc_entry[i] = tolower(vc_entry[i]);
 		}
-		strcat(vc_entry, "=");
+		g_strlcat(vc_entry, "=", vc_entry_size);
 		vc_len = strlen(vc_entry);
 
 		if (META_FIELD_TEXT(frame->type)) {

--- a/src/metadata_ogg.c
+++ b/src/metadata_ogg.c
@@ -746,11 +746,11 @@ meta_ogg_vc_render(metadata_t * meta, unsigned int * length) {
 			field_val = frame->field_val;
 			field_len = strlen(frame->field_val);
 		} else if (META_FIELD_INT(frame->type)) {
-			snprintf(fval, MAXLEN-1, renderfmt, frame->int_val);
+			arr_snprintf(fval, renderfmt, frame->int_val);
 			field_val = fval;
 			field_len = strlen(field_val);
 		} else if (META_FIELD_FLOAT(frame->type)) {
-			snprintf(fval, MAXLEN-1, renderfmt, frame->float_val);
+			arr_snprintf(fval, renderfmt, frame->float_val);
 			field_val = fval;
 			field_len = strlen(field_val);
 		} else {

--- a/src/music_browser.c
+++ b/src/music_browser.c
@@ -589,7 +589,7 @@ create_music_browser(void) {
 
 	/* load tree icons */
         if (options.enable_ms_tree_icons) {
-		sprintf(path, "%s/%s", AQUALUNG_DATADIR, "ms-store.png");
+		arr_snprintf(path, "%s/%s", AQUALUNG_DATADIR, "ms-store.png");
 		icon_store = gdk_pixbuf_new_from_file (path, NULL);
 		store_file_load_icons();
 #ifdef HAVE_CDDA

--- a/src/music_browser.c
+++ b/src/music_browser.c
@@ -832,7 +832,7 @@ music_store_mark_changed(GtkTreeIter * iter) {
 
 	name[0] = '*';
 	name[1] = '\0';
-	strncat(name, pname, MAXLEN-2);
+	arr_strlcat(name, pname);
 	g_free(pname);
 
 	gtk_tree_store_set(music_store, &iter_store, MS_COL_NAME, name, -1);

--- a/src/music_browser.c
+++ b/src/music_browser.c
@@ -665,7 +665,7 @@ create_music_browser(void) {
 			    sizeof(target_table) / sizeof(GtkTargetEntry),
 			    GDK_ACTION_COPY);
 
-	snprintf(path, MAXLEN-1, "%s/drag.png", AQUALUNG_DATADIR);
+	arr_snprintf(path, "%s/drag.png", AQUALUNG_DATADIR);
 	if ((pixbuf = gdk_pixbuf_new_from_file(path, NULL)) != NULL) {
 		gtk_drag_source_set_icon_pixbuf(music_tree, pixbuf);
 	}
@@ -926,7 +926,7 @@ music_store_load_all(void) {
 
 		switch (music_store_get_type(store_file)) {
 		case STORE_TYPE_FILE:
-			snprintf(sort, 15, "%03d", i+1);
+			arr_snprintf(sort, "%03d", i+1);
 			store_file_load(store_file, sort);
 			break;
 		}

--- a/src/options.c
+++ b/src/options.c
@@ -690,7 +690,7 @@ options_window_accept(void) {
 	set_option_from_toggle(check_batch_mpeg_add_id3v2, &options.batch_mpeg_add_id3v2);
 	set_option_from_toggle(check_batch_mpeg_add_ape, &options.batch_mpeg_add_ape);
 
-	set_option_from_entry(encode_set_entry, options.encode_set, MAXLEN);
+	set_option_from_entry(encode_set_entry, options.encode_set, CHAR_ARRAY_SIZE(options.encode_set));
 
 	set_option_from_toggle(check_metaedit_auto_clone, &options.metaedit_auto_clone);
 	set_option_from_toggle(check_meta_use_basename_only, &options.meta_use_basename_only);
@@ -721,7 +721,7 @@ options_window_accept(void) {
 
 	/* CDDB */
 #ifdef HAVE_CDDB
-	set_option_from_entry(cddb_server_entry, options.cddb_server, MAXLEN);
+	set_option_from_entry(cddb_server_entry, options.cddb_server, CHAR_ARRAY_SIZE(options.cddb_server));
 	set_option_from_spin(cddb_tout_spinner, &options.cddb_timeout);
 	set_option_from_combo(cddb_proto_combo, &options.cddb_use_http);
 #endif /* HAVE_CDDB */
@@ -730,9 +730,9 @@ options_window_accept(void) {
 	/* Internet */
 
         set_option_from_toggle(inet_radio_proxy, &options.inet_use_proxy);
-	set_option_from_entry(inet_entry_proxy, options.inet_proxy, MAXLEN);
+	set_option_from_entry(inet_entry_proxy, options.inet_proxy, CHAR_ARRAY_SIZE(options.inet_proxy));
 	set_option_from_spin(inet_spinner_proxy_port, &options.inet_proxy_port);
-	set_option_from_entry(inet_entry_noproxy_domains, options.inet_noproxy_domains, MAXLEN);
+	set_option_from_entry(inet_entry_noproxy_domains, options.inet_noproxy_domains, CHAR_ARRAY_SIZE(options.inet_noproxy_domains));
 	set_option_from_spin(inet_spinner_timeout, &options.inet_timeout);
 
 
@@ -740,13 +740,13 @@ options_window_accept(void) {
 
         set_option_from_toggle(check_disable_skin_support, &options.disable_skin_support_settings);
         set_option_from_toggle(check_override_skin, &options.override_skin_settings);
-	set_option_from_entry(entry_pl_font, options.playlist_font, MAX_FONTNAME_LEN);
-	set_option_from_entry(entry_ms_font, options.browser_font, MAX_FONTNAME_LEN);
-	set_option_from_entry(entry_bt_font, options.bigtimer_font, MAX_FONTNAME_LEN);
-	set_option_from_entry(entry_st_font, options.smalltimer_font, MAX_FONTNAME_LEN);
-	set_option_from_entry(entry_songt_font, options.songtitle_font, MAX_FONTNAME_LEN);
-	set_option_from_entry(entry_si_font, options.songinfo_font, MAX_FONTNAME_LEN);
-	set_option_from_entry(entry_sb_font, options.statusbar_font, MAX_FONTNAME_LEN);
+	set_option_from_entry(entry_pl_font, options.playlist_font, CHAR_ARRAY_SIZE(options.playlist_font));
+	set_option_from_entry(entry_ms_font, options.browser_font, CHAR_ARRAY_SIZE(options.browser_font));
+	set_option_from_entry(entry_bt_font, options.bigtimer_font, CHAR_ARRAY_SIZE(options.bigtimer_font));
+	set_option_from_entry(entry_st_font, options.smalltimer_font, CHAR_ARRAY_SIZE(options.smalltimer_font));
+	set_option_from_entry(entry_songt_font, options.songtitle_font, CHAR_ARRAY_SIZE(options.songtitle_font));
+	set_option_from_entry(entry_si_font, options.songinfo_font, CHAR_ARRAY_SIZE(options.songinfo_font));
+	set_option_from_entry(entry_sb_font, options.statusbar_font, CHAR_ARRAY_SIZE(options.statusbar_font));
 
         /* refresh GUI */
 	for (i = 0; i < 3; i++) {

--- a/src/options.c
+++ b/src/options.c
@@ -473,7 +473,7 @@ music_store_add_new_stores() {
 		int has;
 		char sort[16];
 
-		snprintf(sort, 15, "%03d", i+1);
+		arr_snprintf(sort, "%03d", i+1);
 
 		gtk_tree_model_get(GTK_TREE_MODEL(ms_pathlist_store), &iter, 0, &file, -1);
 
@@ -1307,7 +1307,7 @@ add_ms_pathlist_clicked(GtkButton * button, gpointer * data) {
 	}
 
 	if (pname[0] == '~') {
-		snprintf(name, MAXLEN - 1, "%s%s", options.home, pname + 1);
+		arr_snprintf(name, "%s%s", options.home, pname + 1);
 	} else if (pname[0] == '/') {
 		strncpy(name, pname, MAXLEN - 1);
 	} else {
@@ -3750,27 +3750,27 @@ create_options_window(void) {
         xmlNewTextChild(root, NULL, (const xmlChar *) #Var, (xmlChar *) options.Var);
 
 #define SAVE_FONT(Font) \
-	snprintf(str, MAX_FONTNAME_LEN, "%s", options.Font); \
+	arr_snprintf(str, "%s", options.Font); \
         xmlNewTextChild(root, NULL, (const xmlChar *) #Font, (xmlChar *) str);
 
 #define SAVE_COLOR(Color) \
-	snprintf(str, MAX_COLORNAME_LEN, "%s", options.Color); \
+	arr_snprintf(str, "%s", options.Color); \
         xmlNewTextChild(root, NULL, (const xmlChar *) #Color, (xmlChar *) str);
 
 #define SAVE_INT(Var) \
-	snprintf(str, 31, "%d", options.Var); \
+	arr_snprintf(str, "%d", options.Var); \
         xmlNewTextChild(root, NULL, (const xmlChar *) #Var, (xmlChar *) str);
 
 #define SAVE_INT_ARRAY(Var, Idx) \
-        snprintf(str, 31, "%d", options.Var[Idx]); \
+        arr_snprintf(str, "%d", options.Var[Idx]); \
         xmlNewTextChild(root, NULL, (const xmlChar *) #Var "_" #Idx, (xmlChar *) str);
 
 #define SAVE_INT_SH(Var) \
-	snprintf(str, 31, "%d", options.Var##_shadow); \
+	arr_snprintf(str, "%d", options.Var##_shadow); \
         xmlNewTextChild(root, NULL, (const xmlChar *) #Var, (xmlChar *) str);
 
 #define SAVE_FLOAT(Var) \
-        snprintf(str, 31, "%f", options.Var); \
+        arr_snprintf(str, "%f", options.Var); \
         xmlNewTextChild(root, NULL, (const xmlChar *) #Var, (xmlChar *) str);
 
 
@@ -3869,9 +3869,9 @@ save_config(void) {
 	SAVE_INT(main_size_x);
 
 	if (options.playlist_is_embedded && !options.playlist_is_embedded_shadow && options.playlist_on) {
-		snprintf(str, 31, "%d", options.main_size_y - playlist_window->allocation.height - 6);
+		arr_snprintf(str, "%d", options.main_size_y - playlist_window->allocation.height - 6);
 	} else {
-		snprintf(str, 31, "%d", options.main_size_y);
+		arr_snprintf(str, "%d", options.main_size_y);
 	}
         xmlNewTextChild(root, NULL, (const xmlChar *) "main_size_y", (xmlChar *) str);
 
@@ -4382,7 +4382,7 @@ load_config(void) {
 				char path[MAXLEN];
 				char * ppath;
 
-				snprintf(path, MAXLEN - 1, "%s", (char *)key);
+				arr_snprintf(path, "%s", (char *)key);
 				ppath = g_filename_from_utf8(path, -1, NULL, NULL, NULL);
 
 				append_ms_pathlist(ppath, path);
@@ -4437,10 +4437,10 @@ save_systray_options(xmlDocPtr doc, xmlNodePtr root) {
 		cur = xmlNewNode(NULL, (const xmlChar *) "mouse_button");
 		xmlAddChild(root, cur);
 
-		snprintf(str, sizeof(str), "%d", options.systray_mouse_buttons[i].button_nr);
+		arr_snprintf(str, "%d", options.systray_mouse_buttons[i].button_nr);
 		xmlSetProp(cur, (const xmlChar *) "number", (const xmlChar *) str);
 
-		snprintf(str, sizeof(str), "%d", options.systray_mouse_buttons[i].command);
+		arr_snprintf(str, "%d", options.systray_mouse_buttons[i].command);
 		xmlSetProp(cur, (const xmlChar *) "command", (const xmlChar *) str);
 	}
 }

--- a/src/options.c
+++ b/src/options.c
@@ -3491,7 +3491,7 @@ create_options_window(void) {
 		gtk_entry_set_text(GTK_ENTRY(entry_pl_font), options.playlist_font);
         } else {
                 gtk_entry_set_text(GTK_ENTRY(entry_pl_font), DEFAULT_FONT_NAME);
-                strcpy(options.playlist_font, DEFAULT_FONT_NAME);
+                arr_strlcpy(options.playlist_font, DEFAULT_FONT_NAME);
         }
 
         button_pl_font =  gui_stock_label_button(_("Select"), GTK_STOCK_SELECT_FONT);
@@ -3520,7 +3520,7 @@ create_options_window(void) {
 	        gtk_entry_set_text(GTK_ENTRY(entry_ms_font), options.browser_font);
         } else {
                 gtk_entry_set_text(GTK_ENTRY(entry_ms_font), DEFAULT_FONT_NAME);
-                strcpy(options.browser_font, DEFAULT_FONT_NAME);
+                arr_strlcpy(options.browser_font, DEFAULT_FONT_NAME);
         }
 
         button_ms_font = gui_stock_label_button(_("Select"), GTK_STOCK_SELECT_FONT);
@@ -3549,7 +3549,7 @@ create_options_window(void) {
 	        gtk_entry_set_text(GTK_ENTRY(entry_bt_font), options.bigtimer_font);
         } else {
                 gtk_entry_set_text(GTK_ENTRY(entry_bt_font), DEFAULT_FONT_NAME);
-                strcpy(options.bigtimer_font, DEFAULT_FONT_NAME);
+                arr_strlcpy(options.bigtimer_font, DEFAULT_FONT_NAME);
         }
 
         button_bt_font = gui_stock_label_button(_("Select"), GTK_STOCK_SELECT_FONT);
@@ -3578,7 +3578,7 @@ create_options_window(void) {
 	        gtk_entry_set_text(GTK_ENTRY(entry_st_font), options.smalltimer_font);
         } else {
                 gtk_entry_set_text(GTK_ENTRY(entry_st_font), DEFAULT_FONT_NAME);
-                strcpy(options.smalltimer_font, DEFAULT_FONT_NAME);
+                arr_strlcpy(options.smalltimer_font, DEFAULT_FONT_NAME);
         }
 
         button_st_font = gui_stock_label_button(_("Select"), GTK_STOCK_SELECT_FONT);
@@ -3607,7 +3607,7 @@ create_options_window(void) {
 	        gtk_entry_set_text(GTK_ENTRY(entry_songt_font), options.songtitle_font);
         } else {
                 gtk_entry_set_text(GTK_ENTRY(entry_songt_font), DEFAULT_FONT_NAME);
-                strcpy(options.songtitle_font, DEFAULT_FONT_NAME);
+                arr_strlcpy(options.songtitle_font, DEFAULT_FONT_NAME);
         }
 
         button_songt_font = gui_stock_label_button(_("Select"), GTK_STOCK_SELECT_FONT);
@@ -3636,7 +3636,7 @@ create_options_window(void) {
 	        gtk_entry_set_text(GTK_ENTRY(entry_si_font), options.songinfo_font);
         } else {
                 gtk_entry_set_text(GTK_ENTRY(entry_si_font), DEFAULT_FONT_NAME);
-                strcpy(options.songinfo_font, DEFAULT_FONT_NAME);
+                arr_strlcpy(options.songinfo_font, DEFAULT_FONT_NAME);
         }
 
         button_si_font = gui_stock_label_button(_("Select"), GTK_STOCK_SELECT_FONT);
@@ -3665,7 +3665,7 @@ create_options_window(void) {
 	        gtk_entry_set_text(GTK_ENTRY(entry_sb_font), options.statusbar_font);
         } else {
                 gtk_entry_set_text(GTK_ENTRY(entry_sb_font), DEFAULT_FONT_NAME);
-                strcpy(options.statusbar_font, DEFAULT_FONT_NAME);
+                arr_strlcpy(options.statusbar_font, DEFAULT_FONT_NAME);
         }
 
         button_sb_font = gui_stock_label_button(_("Select"), GTK_STOCK_SELECT_FONT);
@@ -4187,7 +4187,7 @@ load_config(void) {
 	options.systray_mouse_buttons_count = 0;
 	options.systray_mouse_buttons = NULL;
 
-	strcpy(options.export_template, "track%i.%x");
+	arr_strlcpy(options.export_template, "track%i.%x");
 	options.export_subdir_limit = 16;
         options.export_bitrate = 256;
         options.export_vbr = 1;
@@ -4393,7 +4393,7 @@ load_config(void) {
 		if (!options.title_format[0] ||
 		    make_string_va(buf, CHAR_ARRAY_SIZE(buf), options.title_format,
 				   'a', "a", 'r', "r", 't', "t", 0) != 0) {
-			strcpy(options.title_format, "%a?ar|at{ :: }%r?rt{ :: }%t");
+			arr_strlcpy(options.title_format, "%a?ar|at{ :: }%r?rt{ :: }%t");
 		}
 	}
 

--- a/src/options.c
+++ b/src/options.c
@@ -4002,23 +4002,7 @@ save_config(void) {
                 if ((!xmlStrcmp(cur->name, (const xmlChar *) #Var))) { \
 			key = xmlNodeListGetString(doc, cur->xmlChildrenNode, 1); \
                         if (key != NULL) \
-                                strncpy(options.Var, (char *) key, MAXLEN-1); \
-                        xmlFree(key); \
-                }
-
-#define LOAD_FONT(Font) \
-                if ((!xmlStrcmp(cur->name, (const xmlChar *)#Font))) { \
-			key = xmlNodeListGetString(doc, cur->xmlChildrenNode, 1); \
-                        if (key != NULL) \
-                                strncpy(options.Font, (char *) key, MAX_FONTNAME_LEN-1); \
-                        xmlFree(key); \
-                }
-
-#define LOAD_COLOR(Color) \
-                if ((!xmlStrcmp(cur->name, (const xmlChar *) #Color))) { \
-			key = xmlNodeListGetString(doc, cur->xmlChildrenNode, 1); \
-                        if (key != NULL) \
-                                strncpy(options.Color, (char *) key, MAX_COLORNAME_LEN-1); \
+                                arr_strlcpy(options.Var, (char *) key); \
                         xmlFree(key); \
                 }
 
@@ -4319,15 +4303,15 @@ load_config(void) {
 		LOAD_INT_SH(enable_playlist_statusbar);
 		LOAD_INT(ifpmanager_size_x);
 		LOAD_INT(ifpmanager_size_y);
-		LOAD_FONT(browser_font);
-		LOAD_FONT(playlist_font);
-		LOAD_FONT(bigtimer_font);
-		LOAD_FONT(smalltimer_font);
-		LOAD_FONT(songtitle_font);
-		LOAD_FONT(songinfo_font);
-		LOAD_FONT(statusbar_font);
-		LOAD_COLOR(song_color);
-		LOAD_COLOR(activesong_color);
+		LOAD_STR(browser_font);
+		LOAD_STR(playlist_font);
+		LOAD_STR(bigtimer_font);
+		LOAD_STR(smalltimer_font);
+		LOAD_STR(songtitle_font);
+		LOAD_STR(songinfo_font);
+		LOAD_STR(statusbar_font);
+		LOAD_STR(song_color);
+		LOAD_STR(activesong_color);
 		LOAD_INT(repeat_on);
 		LOAD_INT(repeat_all_on);
 		LOAD_INT(shuffle_on);

--- a/src/options.c
+++ b/src/options.c
@@ -542,7 +542,7 @@ options_window_accept(void) {
 	char * ext_title;
 	ext_title = (char *)gtk_entry_get_text(GTK_ENTRY(entry_ext_title_format_file));
 	if(strncmp(ext_title, options.ext_title_format_file, MAXLEN-1)) {
-		strncpy(options.ext_title_format_file, ext_title, MAXLEN-1);
+		arr_strlcpy(options.ext_title_format_file, ext_title);
 		setup_extended_title_formatting();
 	}
 #endif /* HAVE_LUA */
@@ -567,8 +567,8 @@ options_window_accept(void) {
 		title_format_changed = 1;
 	}
 
-	strncpy(options.title_format, gtk_entry_get_text(GTK_ENTRY(entry_title)), MAXLEN-1);
-	strncpy(options.default_param, gtk_entry_get_text(GTK_ENTRY(entry_param)), MAXLEN-1);
+	arr_strlcpy(options.title_format, gtk_entry_get_text(GTK_ENTRY(entry_title)));
+	arr_strlcpy(options.default_param, gtk_entry_get_text(GTK_ENTRY(entry_param)));
 
 	set_option_from_toggle(check_enable_tooltips, &options.enable_tooltips);
 	aqualung_tooltips_set_enabled(options.enable_tooltips);
@@ -1192,9 +1192,9 @@ color_selected(GtkColorButton *widget, gpointer user_data) {
         arr_snprintf(str, "#%02X%02X%02X", c.red * 256 / 65536, c.green * 256 / 65536, c.blue * 256 / 65536);
 
         if (GPOINTER_TO_INT(user_data) == SONG_COLOR) {
-                strncpy(options.song_color, str, MAX_COLORNAME_LEN-1);
+                arr_strlcpy(options.song_color, str);
         } else {
-                strncpy(options.activesong_color, str, MAX_COLORNAME_LEN-1);
+                arr_strlcpy(options.activesong_color, str);
         }
 }
 
@@ -1310,7 +1310,7 @@ add_ms_pathlist_clicked(GtkButton * button, gpointer * data) {
 	if (pname[0] == '~') {
 		arr_snprintf(name, "%s%s", options.home, pname + 1);
 	} else if (pname[0] == '/') {
-		strncpy(name, pname, MAXLEN - 1);
+		arr_strlcpy(name, pname);
 	} else {
 		message_dialog(_("Warning"),
 			       options_window,
@@ -1354,7 +1354,7 @@ add_ms_pathlist_clicked(GtkButton * button, gpointer * data) {
 	gtk_entry_set_text(GTK_ENTRY(entry_ms_pathlist), "");
 
 	append_ms_pathlist(path, name);
-	strncpy(options.storedir, name, MAXLEN-1);
+	arr_strlcpy(options.storedir, name);
 
 	g_free(path);
 }
@@ -2007,9 +2007,9 @@ create_options_window(void) {
 	reskin_flag = 0;
         appearance_changed = 0;
 	if (options.ext_title_format_file[0] == '\0') {
-		strncpy(ext_title_format_file_shadow, options.confdir, MAXLEN-1);
+		arr_strlcpy(ext_title_format_file_shadow, options.confdir);
 	} else {
-		strncpy(ext_title_format_file_shadow, options.ext_title_format_file, MAXLEN-1);
+		arr_strlcpy(ext_title_format_file_shadow, options.ext_title_format_file);
 	}
 
 	if (!restart_list_store) {
@@ -4200,7 +4200,7 @@ load_config(void) {
 	options.batch_tag_flags = BATCH_TAG_TITLE | BATCH_TAG_ARTIST | BATCH_TAG_ALBUM |
 		BATCH_TAG_YEAR | BATCH_TAG_COMMENT | BATCH_TAG_TRACKNO;
 
-        strncpy(options.song_color, "#888888", MAX_COLORNAME_LEN-1);
+        arr_strlcpy(options.song_color, "#888888");
 
 	ms_pathlist_store = gtk_list_store_new(3,
 					       G_TYPE_STRING,   /* path */

--- a/src/options.c
+++ b/src/options.c
@@ -1846,7 +1846,8 @@ options_dialog_response(GtkDialog * dialog, gint response_id, gpointer data) {
 
         current_notebook_page = gtk_notebook_get_current_page(GTK_NOTEBOOK(notebook));
 
-	if ((ret = make_string_va(buf, format, 'a', "a", 'r', "r", 't', "t", 0)) != 0) {
+	if ((ret = make_string_va(buf, CHAR_ARRAY_SIZE(buf), format,
+				  'a', "a", 'r', "r", 't', "t", 0)) != 0) {
 		make_string_strerror(ret, buf, CHAR_ARRAY_SIZE(buf));
 		message_dialog(_("Error in title format string"),
 			       options_window,
@@ -4390,7 +4391,8 @@ load_config(void) {
 	{
 		char buf[MAXLEN];
 		if (!options.title_format[0] ||
-		    make_string_va(buf, options.title_format, 'a', "a", 'r', "r", 't', "t", 0) != 0) {
+		    make_string_va(buf, CHAR_ARRAY_SIZE(buf), options.title_format,
+				   'a', "a", 'r', "r", 't', "t", 0) != 0) {
 			strcpy(options.title_format, "%a?ar|at{ :: }%r?rt{ :: }%t");
 		}
 	}

--- a/src/options.c
+++ b/src/options.c
@@ -1189,7 +1189,7 @@ color_selected(GtkColorButton *widget, gpointer user_data) {
 
         appearance_changed = 1;
         gtk_color_button_get_color(widget, &c);
-        sprintf(str, "#%02X%02X%02X", c.red * 256 / 65536, c.green * 256 / 65536, c.blue * 256 / 65536);
+        arr_snprintf(str, "#%02X%02X%02X", c.red * 256 / 65536, c.green * 256 / 65536, c.blue * 256 / 65536);
 
         if (GPOINTER_TO_INT(user_data) == SONG_COLOR) {
                 strncpy(options.song_color, str, MAX_COLORNAME_LEN-1);
@@ -1213,7 +1213,7 @@ create_notebook_tab(char * text, char * imgfile) {
 	label = gtk_label_new(text);
 	gtk_box_pack_end(GTK_BOX(vbox), label, FALSE, FALSE, 0);
 
-	sprintf(path, "%s/%s", AQUALUNG_DATADIR, imgfile);
+	arr_snprintf(path, "%s/%s", AQUALUNG_DATADIR, imgfile);
 
         pixbuf = gdk_pixbuf_new_from_file(path, NULL);
 
@@ -3791,7 +3791,7 @@ save_config(void) {
 	int i = 0;
 	char * path;
 
-        sprintf(config_file, "%s/config.xml", options.confdir);
+        arr_snprintf(config_file, "%s/config.xml", options.confdir);
 
         doc = xmlNewDoc((const xmlChar *) "1.0");
         root = xmlNewNode(NULL, (const xmlChar *) "aqualung_config");
@@ -3968,7 +3968,7 @@ save_config(void) {
 	save_jack_connections(doc, root);
 #endif /* HAVE_JACK */
 
-        sprintf(tmpname, "%s/config.xml.temp", options.confdir);
+        arr_snprintf(tmpname, "%s/config.xml.temp", options.confdir);
         xmlSaveFormatFile(tmpname, doc, 1);
 	xmlFreeDoc(doc);
 
@@ -4069,7 +4069,7 @@ load_config(void) {
         FILE * f;
 
 
-        sprintf(config_file, "%s/config.xml", options.confdir);
+        arr_snprintf(config_file, "%s/config.xml", options.confdir);
 
         if ((f = fopen(config_file, "rt")) == NULL) {
 		/* no warning -- done that in core.c::load_default_cl() */

--- a/src/options.c
+++ b/src/options.c
@@ -1261,7 +1261,8 @@ browse_ext_title_format_file_clicked(GtkButton * button, gpointer data) {
 				GTK_FILE_CHOOSER_ACTION_OPEN,
 				FILE_CHOOSER_FILTER_ETF,
 				(GtkWidget *)data,
-				ext_title_format_file_shadow);
+				ext_title_format_file_shadow,
+				CHAR_ARRAY_SIZE(ext_title_format_file_shadow));
 }
 #endif /* HAVE_LUA */
 
@@ -1273,7 +1274,7 @@ browse_ms_pathlist_clicked(GtkButton * button, gpointer data) {
 				GTK_FILE_CHOOSER_ACTION_OPEN,
 				FILE_CHOOSER_FILTER_STORE,
 				(GtkWidget *)data,
-				options.storedir);
+				options.storedir, CHAR_ARRAY_SIZE(options.storedir));
 }
 
 

--- a/src/options.c
+++ b/src/options.c
@@ -1847,7 +1847,7 @@ options_dialog_response(GtkDialog * dialog, gint response_id, gpointer data) {
         current_notebook_page = gtk_notebook_get_current_page(GTK_NOTEBOOK(notebook));
 
 	if ((ret = make_string_va(buf, format, 'a', "a", 'r', "r", 't', "t", 0)) != 0) {
-		make_string_strerror(ret, buf);
+		make_string_strerror(ret, buf, CHAR_ARRAY_SIZE(buf));
 		message_dialog(_("Error in title format string"),
 			       options_window,
 			       GTK_MESSAGE_ERROR,

--- a/src/playlist.c
+++ b/src/playlist.c
@@ -2161,7 +2161,7 @@ playlist_load(GSList * list, int mode, char * tab_name, int start_playback) {
 
 	for (node = list; node; node = node->next) {
 
-		normalize_filename((char *)node->data, fullname);
+		normalize_filename((char *)node->data, fullname, CHAR_ARRAY_SIZE(fullname));
 		type = playlist_get_type(fullname);
 
 		if (type != PLAYLIST_XML_MULTI) {

--- a/src/playlist.c
+++ b/src/playlist.c
@@ -971,8 +971,8 @@ playlist_set_color(void) {
         	bi = playlist_color_indicator->style->fg[GTK_STATE_INSENSITIVE].blue;
         }
 
-        sprintf(active, "#%04X%04X%04X", rs, gs, bs);
-	sprintf(inactive, "#%04X%04X%04X", ri, gi, bi);
+	arr_snprintf(active, "#%04X%04X%04X", rs, gs, bs);
+	arr_snprintf(inactive, "#%04X%04X%04X", ri, gi, bi);
 
 	for (node = playlists; node; node = node->next) {
 		playlist_t * pl = (playlist_t *)node->data;
@@ -1127,7 +1127,7 @@ mark_track(playlist_t * pl, GtkTreeIter * piter) {
 			return;
 		}
 
-                sprintf(counter, _(" (%d/%d)"), j, n);
+                arr_snprintf(counter, _(" (%d/%d)"), j, n);
                 arr_strlcat(tmpname, counter);
 		gtk_tree_store_set(pl->store, piter, PL_COL_NAME, tmpname, -1);
 		data->ntracks = n;
@@ -3177,23 +3177,23 @@ playlist_stats(playlist_t * pl, int selected) {
                 }
 	}
 
-	sprintf(str, " %d %s ", ntrack, (ntrack == 1) ? _("track") : _("tracks"));
+	arr_snprintf(str, " %d %s ", ntrack, (ntrack == 1) ? _("track") : _("tracks"));
 
 	if (length > 0.0f || ntrack == 0) {
 		time2time(length, length_str, CHAR_ARRAY_SIZE(length_str));
-		sprintf(tmp, " [%s] ", length_str);
+		arr_snprintf(tmp, " [%s] ", length_str);
 		strcat(str, tmp);
 	}
 
 	if (options.pl_statusbar_show_size) {
 		if (size > 1024 * 1024) {
-			sprintf(tmp, " (%.1f GB) ", size / (1024 * 1024));
+			arr_snprintf(tmp, " (%.1f GB) ", size / (1024 * 1024));
 	        	strcat(str, tmp);
 		} else if (size > (1 << 10)){
-			sprintf(tmp, " (%.1f MB) ", size / 1024);
+			arr_snprintf(tmp, " (%.1f MB) ", size / 1024);
         		strcat(str, tmp);
 		} else if (size > 0 || ntrack == 0) {
-			sprintf(tmp, " (%.1f KB) ", size);
+			arr_snprintf(tmp, " (%.1f KB) ", size);
 		        strcat(str, tmp);
 		}
 	}
@@ -3263,7 +3263,7 @@ playlist_drag_data_get(GtkWidget * widget, GdkDragContext * drag_context,
 		      GtkSelectionData * data, guint info, guint time, gpointer user_data) {
 
 	char tmp[32];
-	sprintf(tmp, "%p", user_data);
+	arr_snprintf(tmp, "%p", user_data);
 	gtk_selection_data_set(data, gtk_selection_data_get_target(data), 8,
 			       (guchar *)tmp, strlen(tmp));
 }
@@ -3859,7 +3859,7 @@ create_playlist_tab_label(playlist_t * pl) {
 
 	pl->tab_close_button = gtk_button_new();
 	gtk_widget_set_name(pl->tab_close_button, "playlist_tab_close_button");
-	sprintf(path, "%s/tab-close.png", AQUALUNG_DATADIR);
+	arr_snprintf(path, "%s/tab-close.png", AQUALUNG_DATADIR);
 	if ((pixbuf = gdk_pixbuf_new_from_file(path, NULL)) != NULL) {
 		image = gtk_image_new_from_pixbuf(pixbuf);
 		gtk_container_add(GTK_CONTAINER(pl->tab_close_button), image);

--- a/src/playlist.c
+++ b/src/playlist.c
@@ -3182,19 +3182,19 @@ playlist_stats(playlist_t * pl, int selected) {
 	if (length > 0.0f || ntrack == 0) {
 		time2time(length, length_str, CHAR_ARRAY_SIZE(length_str));
 		arr_snprintf(tmp, " [%s] ", length_str);
-		strcat(str, tmp);
+		arr_strlcat(str, tmp);
 	}
 
 	if (options.pl_statusbar_show_size) {
 		if (size > 1024 * 1024) {
 			arr_snprintf(tmp, " (%.1f GB) ", size / (1024 * 1024));
-	        	strcat(str, tmp);
+			arr_strlcat(str, tmp);
 		} else if (size > (1 << 10)){
 			arr_snprintf(tmp, " (%.1f MB) ", size / 1024);
-        		strcat(str, tmp);
+			arr_strlcat(str, tmp);
 		} else if (size > 0 || ntrack == 0) {
 			arr_snprintf(tmp, " (%.1f KB) ", size);
-		        strcat(str, tmp);
+			arr_strlcat(str, tmp);
 		}
 	}
 

--- a/src/playlist.c
+++ b/src/playlist.c
@@ -605,7 +605,7 @@ playlist_node_copy(GtkTreeStore * sstore, GtkTreeIter * siter,
 
 		if (IS_PL_ALBUM_NODE(tdata)) {
 			char name[MAXLEN];
-			snprintf(name, MAXLEN-1, "%s: %s", tdata->artist, tdata->album);
+			arr_snprintf(name, "%s: %s", tdata->artist, tdata->album);
 			gtk_tree_store_set(tstore, iter, PL_COL_NAME, name, -1);
 		}
 	}
@@ -1165,7 +1165,7 @@ unmark_track(playlist_t * pl, GtkTreeIter * piter) {
 		playlist_data_t * data;
 
 		gtk_tree_model_get(model, piter, PL_COL_DATA, &data, -1);
-		snprintf(name, MAXLEN-1, "%s: %s", data->artist, data->album);
+		arr_snprintf(name, "%s: %s", data->artist, data->album);
 		gtk_tree_store_set(pl->store, piter, PL_COL_NAME, name, -1);
 	}
 
@@ -1683,12 +1683,12 @@ add_file_to_playlist(gpointer data) {
 
 		if (IS_PL_ALBUM_NODE(pldata)) {
 			if (IS_PL_ACTIVE(pldata)) {
-				snprintf(list_str, MAXLEN-1, "%s: %s (%d/%d)",
-					 pldata->artist, pldata->album,
-					 pldata->actrack, pldata->ntracks);
+				arr_snprintf(list_str, "%s: %s (%d/%d)",
+					     pldata->artist, pldata->album,
+					     pldata->actrack, pldata->ntracks);
 			} else {
-				snprintf(list_str, MAXLEN-1, "%s: %s",
-					 pldata->artist, pldata->album);
+				arr_snprintf(list_str, "%s: %s",
+					     pldata->artist, pldata->album);
 			}
 		} else if (IS_PL_ALBUM_CHILD(pldata)) {
 			GtkTreeIter parent;
@@ -1878,7 +1878,7 @@ add_dir_to_playlist(playlist_transfer_t * pt, char * dirname) {
 			break;
 		}
 
-		snprintf(path, MAXLEN-1, "%s/%s", dirname, ent[i]->d_name);
+		arr_snprintf(path, "%s/%s", dirname, ent[i]->d_name);
 
 		if (!g_file_test(path, G_FILE_TEST_EXISTS)) {
 			free(ent[i]);
@@ -4045,7 +4045,7 @@ create_playlist_gui(playlist_t * pl) {
 			  sizeof(target_table) / sizeof(GtkTargetEntry),
 			  GDK_ACTION_MOVE | GDK_ACTION_COPY);
 
-	snprintf(path, MAXLEN-1, "%s/drag.png", AQUALUNG_DATADIR);
+	arr_snprintf(path, "%s/drag.png", AQUALUNG_DATADIR);
 	if ((pixbuf = gdk_pixbuf_new_from_file(path, NULL)) != NULL) {
 		gtk_drag_source_set_icon_pixbuf(pl->view, pixbuf);
 	}
@@ -4478,22 +4478,22 @@ save_track_node(playlist_t * pl, GtkTreeIter * piter, xmlNodePtr root, char * no
 		xmlNewTextChild(node, NULL, (const xmlChar*) "file", (const xmlChar*) file);
 		g_free(file);
 
-		snprintf(str, 31, "%f", data->voladj);
+		arr_snprintf(str, "%f", data->voladj);
 		xmlNewTextChild(node, NULL, (const xmlChar*) "voladj", (const xmlChar*) str);
 
-		snprintf(str, 31, "%u", data->size);
+		arr_snprintf(str, "%u", data->size);
 		xmlNewTextChild(node, NULL, (const xmlChar*) "size", (const xmlChar*) str);
 
 	} else if (IS_PL_ACTIVE(data)){
 
-		snprintf(str, 31, "%u", data->ntracks);
+		arr_snprintf(str, "%u", data->ntracks);
 		xmlNewTextChild(node, NULL, (const xmlChar*) "ntracks", (const xmlChar*) str);
 
-		snprintf(str, 31, "%u", data->actrack);
+		arr_snprintf(str, "%u", data->actrack);
 		xmlNewTextChild(node, NULL, (const xmlChar*) "actrack", (const xmlChar*) str);
 	}
 
-	snprintf(str, 31, "%f", data->duration);
+	arr_snprintf(str, "%f", data->duration);
 	xmlNewTextChild(node, NULL, (const xmlChar*) "duration", (const xmlChar*) str);
 
 	if (IS_PL_ACTIVE(data)) {
@@ -4655,7 +4655,7 @@ playlist_auto_save_cb(gpointer data) {
 
 	if (playlist_dirty) {
 		char playlist_name[MAXLEN];
-		snprintf(playlist_name, MAXLEN-1, "%s/%s", options.confdir, "playlist.xml");
+		arr_snprintf(playlist_name, "%s/%s", options.confdir, "playlist.xml");
 		playlist_save_all(playlist_name);
 		playlist_dirty = 0;
 	}
@@ -5068,7 +5068,7 @@ playlist_load_m3u_thread(void * arg) {
 				while ((line[cnt+8] >= '0') && (line[cnt+8] <= '9') && cnt < 63) {
 					++cnt;
 				}
-				snprintf(name, MAXLEN-1, "%s", line+cnt+9);
+				arr_snprintf(name, "%s", line+cnt+9);
 				have_name = 1;
 			} else {
                                 if (!httpc_is_url(line)) {
@@ -5080,7 +5080,7 @@ playlist_load_m3u_thread(void * arg) {
                                                 continue;
                                         }
 
-                                        snprintf(path, MAXLEN-1, "%s", line);
+                                        arr_snprintf(path, "%s", line);
 
                                         /* path curing: turn \-s into /-s */
                                         for (n = 0; n < strlen(path); n++) {
@@ -5090,18 +5090,18 @@ playlist_load_m3u_thread(void * arg) {
 
                                         if (path[0] != '/') {
                                                 strncpy(tmp, path, MAXLEN-1);
-                                                snprintf(path, MAXLEN-1, "%s/%s", pl_dir, tmp);
+                                                arr_snprintf(path, "%s/%s", pl_dir, tmp);
                                         }
 
                                         if (!have_name) {
                                                 gchar * ch;
                                                 if ((ch = strrchr(path, '/')) != NULL) {
                                                         ++ch;
-                                                        snprintf(name, MAXLEN-1, "%s", ch);
+                                                        arr_snprintf(name, "%s", ch);
                                                 } else {
                                                         fprintf(stderr,
                                                                 "warning: ain't this a directory? : %s\n", path);
-                                                        snprintf(name, MAXLEN-1, "%s", path);
+                                                        arr_snprintf(name, "%s", path);
                                                 }
                                         }
 
@@ -5260,7 +5260,7 @@ playlist_load_pls_thread(void * arg) {
                                                 continue;
                                         }
 
-                                        snprintf(file, MAXLEN-1, "%s", ch);
+                                        arr_snprintf(file, "%s", ch);
 
                                         /* path curing: turn \-s into /-s */
 
@@ -5271,11 +5271,11 @@ playlist_load_pls_thread(void * arg) {
 
                                         if (file[0] != '/') {
                                                 strncpy(tmp, file, MAXLEN-1);
-                                                snprintf(file, MAXLEN-1, "%s/%s", pl_dir, tmp);
+                                                arr_snprintf(file, "%s/%s", pl_dir, tmp);
                                         }
 
                                 } else {
-                                        snprintf(file, MAXLEN-1, "%s", ch);
+                                        arr_snprintf(file, "%s", ch);
                                 }
 
 				have_file = 1;
@@ -5303,7 +5303,7 @@ playlist_load_pls_thread(void * arg) {
 				numstr[m] = '\0';
 				strncpy(numstr_title, numstr, sizeof(numstr_title));
 
-				snprintf(title, MAXLEN-1, "%s", ch);
+				arr_snprintf(title, "%s", ch);
 				have_title = 1;
 
 

--- a/src/playlist.c
+++ b/src/playlist.c
@@ -583,7 +583,7 @@ playlist_node_copy(GtkTreeStore * sstore, GtkTreeIter * siter,
 		}
 		if (!name_set) {
 			char list_str[MAXLEN];
-			playlist_data_get_display_name(list_str, tdata);
+			playlist_data_get_display_name(list_str, CHAR_ARRAY_SIZE(list_str), tdata);
 			gtk_tree_store_set(tstore, iter, PL_COL_NAME, list_str, -1);
 		}
 	} else {
@@ -809,7 +809,7 @@ playlist_reset_display_names(void) {
 			if (!gtk_tree_model_iter_has_child(GTK_TREE_MODEL(pl->store), &iter)) {
 				gtk_tree_model_get(GTK_TREE_MODEL(pl->store), &iter, PL_COL_DATA, &data, -1);
 				if (!httpc_is_url(data->file)) {
-					playlist_data_get_display_name(list_str, data);
+					playlist_data_get_display_name(list_str, CHAR_ARRAY_SIZE(list_str), data);
 					gtk_tree_store_set(pl->store, &iter, PL_COL_NAME, list_str, -1);
 				}
 			}
@@ -1594,21 +1594,21 @@ finalize_add_to_playlist(gpointer data) {
 }
 
 void
-playlist_data_get_display_name(char * list_str, playlist_data_t * pldata) {
+playlist_data_get_display_name(char * list_str, size_t list_str_size, playlist_data_t * pldata) {
 
 	if (pldata->display) {
-		strncpy(list_str, pldata->display, MAXLEN-1);
+		g_strlcpy(list_str, pldata->display, list_str_size);
 	} else if (pldata->artist || pldata->album || pldata->title) {
-		make_title_string(list_str, MAXLEN, options.title_format,
+		make_title_string(list_str, list_str_size, options.title_format,
 				  pldata->artist, pldata->album, pldata->title);
 	} else {
 		gchar * tmp = g_filename_display_name(pldata->file);
 		if (options.meta_use_basename_only) {
 			char * bname = g_path_get_basename(tmp);
-			strncpy(list_str, bname, MAXLEN-1);
+			g_strlcpy(list_str, bname, list_str_size);
 			g_free(bname);
 		} else {
-			strncpy(list_str, tmp, MAXLEN-1);
+			g_strlcpy(list_str, tmp, list_str_size);
 		}
 		g_free(tmp);
 
@@ -1699,11 +1699,11 @@ add_file_to_playlist(gpointer data) {
 				    !strcmp(pdata->artist, pldata->artist) && !strcmp(pdata->album, pldata->album)) {
 					strncpy(list_str, pldata->title, MAXLEN-1);
 				} else {
-					playlist_data_get_display_name(list_str, pldata);
+					playlist_data_get_display_name(list_str, CHAR_ARRAY_SIZE(list_str), pldata);
 				}
 			}
 		} else {
-			playlist_data_get_display_name(list_str, pldata);
+			playlist_data_get_display_name(list_str, CHAR_ARRAY_SIZE(list_str), pldata);
 		}
 
 		gtk_tree_store_set(pt->pl->store, &iter,
@@ -2388,7 +2388,7 @@ plist__reread_file_meta_foreach(playlist_t * pl, GtkTreeIter * iter, void * user
 
 	if (!name_set) {
 		char list_str[MAXLEN];
-		playlist_data_get_display_name(list_str, data);
+		playlist_data_get_display_name(list_str, CHAR_ARRAY_SIZE(list_str), data);
 		gtk_tree_store_set(pl->store, iter, PL_COL_NAME, list_str, -1);
 	}
 

--- a/src/playlist.c
+++ b/src/playlist.c
@@ -366,10 +366,10 @@ playlist_new(char * name) {
 #endif /* !HAVE_LIBPTHREAD */
 
 	if (name != NULL) {
-		strncpy(pl->name, name, MAXLEN-1);
+		arr_strlcpy(pl->name, name);
 		pl->name_set = 1;
 	} else {
-		strncpy(pl->name, _("(Untitled)"), MAXLEN-1);
+		arr_strlcpy(pl->name, _("(Untitled)"));
 	}
 
 	pl->index = -1;
@@ -1112,7 +1112,7 @@ mark_track(playlist_t * pl, GtkTreeIter * piter) {
 		playlist_data_t * data_child;
 
                 gtk_tree_model_get(model, piter,  PL_COL_NAME, &name, -1);
-                strncpy(tmpname, name, MAXLEN-1);
+                arr_strlcpy(tmpname, name);
 
                 j = 0;
 		while (gtk_tree_model_iter_nth_child(model, &iter_child, piter, j++)) {
@@ -1697,7 +1697,7 @@ add_file_to_playlist(gpointer data) {
 				gtk_tree_model_get(GTK_TREE_MODEL(pt->pl->store), &parent, PL_COL_DATA, &pdata, -1);
 				if (pdata->artist && pdata->album && pldata->artist && pldata->album && pldata->title &&
 				    !strcmp(pdata->artist, pldata->artist) && !strcmp(pdata->album, pldata->album)) {
-					strncpy(list_str, pldata->title, MAXLEN-1);
+					arr_strlcpy(list_str, pldata->title);
 				} else {
 					playlist_data_get_display_name(list_str, CHAR_ARRAY_SIZE(list_str), pldata);
 				}
@@ -2033,7 +2033,7 @@ add_url(GtkWidget * widget, gpointer data) {
 		playlist_t * pl = playlist_get_current();
 		playlist_data_t * data;
 
-                strncpy(url, gtk_entry_get_text(GTK_ENTRY(url_entry)), MAXLEN-1);
+                arr_strlcpy(url, gtk_entry_get_text(GTK_ENTRY(url_entry)));
 
 		if (url[0] == '\0' || strstr(url, "http://") != url || strlen(url) <= strlen("http://")) {
 			gtk_widget_grab_focus(url_entry);
@@ -2495,19 +2495,19 @@ plist__export_foreach(playlist_t * pl, GtkTreeIter * iter, void * data) {
 		if (pldata->artist) {
 			strcpy(artist, pldata->artist);
 		} else if (metadata_get_artist(fdec->meta, &tmp)) {
-			strncpy(artist, tmp, MAXLEN-1);
+			arr_strlcpy(artist, tmp);
 		}
 
 		if (pldata->album) {
 			strcpy(album, pldata->album);
 		} else if (metadata_get_album(fdec->meta, &tmp)) {
-			strncpy(album, tmp, MAXLEN-1);
+			arr_strlcpy(album, tmp);
 		}
 
 		if (pldata->title) {
 			strcpy(title, pldata->title);
 		} else if (metadata_get_title(fdec->meta, &tmp)) {
-			strncpy(title, tmp, MAXLEN-1);
+			arr_strlcpy(title, tmp);
 		}
 
 		if (metadata_get_date(fdec->meta, &tmp)) {
@@ -3442,7 +3442,7 @@ playlist_drag_data_received(GtkWidget * widget, GdkDragContext * drag_context, g
 			}
 
 			if ((str = g_filename_from_uri(uri_list[i], NULL, NULL)) != NULL) {
-				strncpy(file, str, MAXLEN-1);
+				arr_strlcpy(file, str);
 				g_free(str);
 			} else {
 				int off = 0;
@@ -3456,11 +3456,11 @@ playlist_drag_data_received(GtkWidget * widget, GdkDragContext * drag_context, g
 					off++;
 				}
 
-				strncpy(file, uri_list[i] + off, MAXLEN-1);
+				arr_strlcpy(file, uri_list[i] + off);
 			}
 
 			if ((str = g_filename_from_utf8(file, -1, NULL, NULL, NULL)) != NULL) {
-				strncpy(file, str, MAXLEN-1);
+				arr_strlcpy(file, str);
 				g_free(str);
 			}
 
@@ -3556,7 +3556,7 @@ void
 playlist_rename(playlist_t * pl, char * name) {
 
 	if (name != NULL) {
-		strncpy(pl->name, name, MAXLEN-1);
+		arr_strlcpy(pl->name, name);
 		pl->name_set = 1;
 		playlist_set_markup(pl);
 	}
@@ -3768,7 +3768,7 @@ tab__rename_cb(gpointer data) {
 	name[0] = '\0';
         if (aqualung_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
 
-                strncpy(name, gtk_entry_get_text(GTK_ENTRY(entry)), MAXLEN-1);
+                arr_strlcpy(name, gtk_entry_get_text(GTK_ENTRY(entry)));
 
 		if (name[0] == '\0') {
 			gtk_widget_grab_focus(entry);
@@ -5091,7 +5091,7 @@ playlist_load_m3u_thread(void * arg) {
                                         }
 
                                         if (path[0] != '/') {
-                                                strncpy(tmp, path, MAXLEN-1);
+                                                arr_strlcpy(tmp, path);
                                                 arr_snprintf(path, "%s/%s", pl_dir, tmp);
                                         }
 
@@ -5252,7 +5252,7 @@ playlist_load_pls_thread(void * arg) {
                                                         numstr[m++] = line[n+4];
                                         }
                                         numstr[m] = '\0';
-                                        strncpy(numstr_file, numstr, sizeof(numstr_file));
+                                        arr_strlcpy(numstr_file, numstr);
 
                                         /* safeguard against C:\ stuff */
                                         if ((ch[1] == ':') && (ch[2] == '\\')) {
@@ -5272,7 +5272,7 @@ playlist_load_pls_thread(void * arg) {
                                         }
 
                                         if (file[0] != '/') {
-                                                strncpy(tmp, file, MAXLEN-1);
+                                                arr_strlcpy(tmp, file);
                                                 arr_snprintf(file, "%s/%s", pl_dir, tmp);
                                         }
 
@@ -5303,7 +5303,7 @@ playlist_load_pls_thread(void * arg) {
 						numstr[m++] = line[n+5];
 				}
 				numstr[m] = '\0';
-				strncpy(numstr_title, numstr, sizeof(numstr_title));
+				arr_strlcpy(numstr_title, numstr);
 
 				arr_snprintf(title, "%s", ch);
 				have_title = 1;

--- a/src/playlist.c
+++ b/src/playlist.c
@@ -1662,7 +1662,7 @@ add_file_to_playlist(gpointer data) {
 		}
 
 		voladj2str(pldata->voladj, voladj_str, CHAR_ARRAY_SIZE(voladj_str));
-		time2time_na(pldata->duration, duration_str);
+		time2time_na(pldata->duration, duration_str, CHAR_ARRAY_SIZE(duration_str));
 
 		if (IS_PL_TOPLEVEL(pldata)) {
 			gtk_tree_store_append(pt->pl->store, &iter, NULL);
@@ -2049,7 +2049,7 @@ add_url(GtkWidget * widget, gpointer data) {
 		data->voladj = options.rva_no_rva_voladj;
 
 		voladj2str(data->voladj, voladj_str, CHAR_ARRAY_SIZE(voladj_str));
-		time2time_na(data->duration, duration_str);
+		time2time_na(data->duration, duration_str, CHAR_ARRAY_SIZE(duration_str));
 
 		gtk_tree_store_append(pl->store, &iter, NULL);
 		gtk_tree_store_set(pl->store, &iter,
@@ -2369,7 +2369,7 @@ plist__reread_file_meta_foreach(playlist_t * pl, GtkTreeIter * iter, void * user
 	playlist_data_free(tmp);
 
 	voladj2str(data->voladj, voladj_str, CHAR_ARRAY_SIZE(voladj_str));
-	time2time_na(data->duration, duration_str);
+	time2time_na(data->duration, duration_str, CHAR_ARRAY_SIZE(duration_str));
 
 	gtk_tree_store_set(pl->store, iter,
 			   PL_COL_VADJ, voladj_str,
@@ -3180,7 +3180,7 @@ playlist_stats(playlist_t * pl, int selected) {
 	sprintf(str, " %d %s ", ntrack, (ntrack == 1) ? _("track") : _("tracks"));
 
 	if (length > 0.0f || ntrack == 0) {
-		time2time(length, length_str);
+		time2time(length, length_str, CHAR_ARRAY_SIZE(length_str));
 		sprintf(tmp, " [%s] ", length_str);
 		strcat(str, tmp);
 	}
@@ -3219,7 +3219,7 @@ recalc_album_node(playlist_t * pl, GtkTreeIter * iter) {
 
 	playlist_child_stats(pl, iter, &ntrack, &length, &size, 0/*false*/);
 
-	time2time(length, time);
+	time2time(length, time, CHAR_ARRAY_SIZE(time));
 	gtk_tree_store_set(pl->store, iter, PL_COL_DURA, time, -1);
 	data->duration = length;
 

--- a/src/playlist.c
+++ b/src/playlist.c
@@ -1128,7 +1128,7 @@ mark_track(playlist_t * pl, GtkTreeIter * piter) {
 		}
 
                 sprintf(counter, _(" (%d/%d)"), j, n);
-                strncat(tmpname, counter, MAXLEN-1);
+                arr_strlcat(tmpname, counter);
 		gtk_tree_store_set(pl->store, piter, PL_COL_NAME, tmpname, -1);
 		data->ntracks = n;
 		data->actrack = j;

--- a/src/playlist.c
+++ b/src/playlist.c
@@ -985,8 +985,8 @@ playlist_set_color(void) {
 		adjust_playlist_color(pl, active, inactive);
 	}
 
-        strcpy(pl_color_active, active);
-	strcpy(pl_color_inactive, inactive);
+	arr_strlcpy(pl_color_active, active);
+	arr_strlcpy(pl_color_inactive, inactive);
 }
 
 void
@@ -2493,19 +2493,19 @@ plist__export_foreach(playlist_t * pl, GtkTreeIter * iter, void * data) {
 		char * tmp;
 
 		if (pldata->artist) {
-			strcpy(artist, pldata->artist);
+			arr_strlcpy(artist, pldata->artist);
 		} else if (metadata_get_artist(fdec->meta, &tmp)) {
 			arr_strlcpy(artist, tmp);
 		}
 
 		if (pldata->album) {
-			strcpy(album, pldata->album);
+			arr_strlcpy(album, pldata->album);
 		} else if (metadata_get_album(fdec->meta, &tmp)) {
 			arr_strlcpy(album, tmp);
 		}
 
 		if (pldata->title) {
-			strcpy(title, pldata->title);
+			arr_strlcpy(title, pldata->title);
 		} else if (metadata_get_title(fdec->meta, &tmp)) {
 			arr_strlcpy(title, tmp);
 		}
@@ -4184,11 +4184,11 @@ create_playlist(void) {
 
 
 	if (pl_color_active[0] == '\0') {
-		strcpy(pl_color_active, "#000080");
+		arr_strlcpy(pl_color_active, "#000080");
 	}
 
 	if (pl_color_inactive[0] == '\0') {
-		strcpy(pl_color_inactive, "#010101");
+		arr_strlcpy(pl_color_inactive, "#010101");
 	}
 
 

--- a/src/playlist.c
+++ b/src/playlist.c
@@ -2564,7 +2564,7 @@ void
 plist__fileinfo_cb(gpointer user_data) {
 
 	playlist_t * pl = playlist_get_current();
-	playlist_data_t * pldata;
+	playlist_data_t * pldata = NULL;
 	GtkTreeIter iter;
 
 	if (!pl) return;
@@ -2580,7 +2580,7 @@ plist__fileinfo_cb(gpointer user_data) {
 		gtk_tree_path_free(p);
 	}
 	show_file_info(GTK_TREE_MODEL(pl->store), iter, playlist_model_func, 0,
-		       FALSE, IS_PL_COVER(pldata));
+		       FALSE, (pldata != NULL && IS_PL_COVER(pldata)));
 }
 
 void

--- a/src/playlist.c
+++ b/src/playlist.c
@@ -1842,7 +1842,8 @@ add_files(GtkWidget * widget, gpointer data) {
 				      GTK_FILE_CHOOSER_ACTION_OPEN,
 				      FILE_CHOOSER_FILTER_AUDIO,
 				      TRUE,
-				      options.audiodir);
+				      options.audiodir,
+				      CHAR_ARRAY_SIZE(options.audiodir));
         if (files != NULL) {
 
 		playlist_transfer_t * pt = playlist_transfer_get(PLAYLIST_ENQUEUE, NULL, 0);
@@ -1949,7 +1950,8 @@ add_directory(GtkWidget * widget, gpointer data) {
 				     GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
 				     FILE_CHOOSER_FILTER_NONE,
 				     TRUE,
-				     options.audiodir);
+				     options.audiodir,
+				     CHAR_ARRAY_SIZE(options.audiodir));
         if (dirs != NULL) {
 
 		playlist_transfer_t * pt = playlist_transfer_get(PLAYLIST_ENQUEUE, NULL, 0);
@@ -2080,7 +2082,7 @@ plist__save_cb(gpointer data) {
 			    GTK_FILE_CHOOSER_ACTION_SAVE,
 			    FILE_CHOOSER_FILTER_NONE,
 			    FALSE,
-			    options.plistdir);
+			    options.plistdir, CHAR_ARRAY_SIZE(options.plistdir));
 
         if (file != NULL) {
 		if (g_str_has_suffix((gchar *)file->data, ".m3u")) {
@@ -2110,7 +2112,7 @@ plist__save_all_cb(gpointer data) {
 			    GTK_FILE_CHOOSER_ACTION_SAVE,
 			    FILE_CHOOSER_FILTER_NONE,
 			    FALSE,
-			    options.plistdir);
+			    options.plistdir, CHAR_ARRAY_SIZE(options.plistdir));
         if (file != NULL) {
 		playlist_save_all((char *)file->data);
                 g_free(file->data);
@@ -2237,7 +2239,7 @@ playlist_load_dialog(int mode) {
 			     GTK_FILE_CHOOSER_ACTION_OPEN,
 			     FILE_CHOOSER_FILTER_PLAYLIST,
 			     FALSE,
-			     options.plistdir);
+			     options.plistdir, CHAR_ARRAY_SIZE(options.plistdir));
         if (files != NULL) {
 		playlist_load(files, mode, NULL, 0);
         }

--- a/src/playlist.c
+++ b/src/playlist.c
@@ -1599,7 +1599,7 @@ playlist_data_get_display_name(char * list_str, playlist_data_t * pldata) {
 	if (pldata->display) {
 		strncpy(list_str, pldata->display, MAXLEN-1);
 	} else if (pldata->artist || pldata->album || pldata->title) {
-		make_title_string(list_str, options.title_format,
+		make_title_string(list_str, MAXLEN, options.title_format,
 				  pldata->artist, pldata->album, pldata->title);
 	} else {
 		gchar * tmp = g_filename_display_name(pldata->file);

--- a/src/playlist.c
+++ b/src/playlist.c
@@ -1661,7 +1661,7 @@ add_file_to_playlist(gpointer data) {
 			break;
 		}
 
-		voladj2str(pldata->voladj, voladj_str);
+		voladj2str(pldata->voladj, voladj_str, CHAR_ARRAY_SIZE(voladj_str));
 		time2time_na(pldata->duration, duration_str);
 
 		if (IS_PL_TOPLEVEL(pldata)) {
@@ -2048,7 +2048,7 @@ add_url(GtkWidget * widget, gpointer data) {
 		data->duration = 0.0f;
 		data->voladj = options.rva_no_rva_voladj;
 
-		voladj2str(data->voladj, voladj_str);
+		voladj2str(data->voladj, voladj_str, CHAR_ARRAY_SIZE(voladj_str));
 		time2time_na(data->duration, duration_str);
 
 		gtk_tree_store_append(pl->store, &iter, NULL);
@@ -2368,7 +2368,7 @@ plist__reread_file_meta_foreach(playlist_t * pl, GtkTreeIter * iter, void * user
 
 	playlist_data_free(tmp);
 
-	voladj2str(data->voladj, voladj_str);
+	voladj2str(data->voladj, voladj_str, CHAR_ARRAY_SIZE(voladj_str));
 	time2time_na(data->duration, duration_str);
 
 	gtk_tree_store_set(pl->store, iter,

--- a/src/playlist.h
+++ b/src/playlist.h
@@ -183,7 +183,7 @@ typedef struct {
 } playlist_data_t;
 
 playlist_data_t * playlist_data_new(void);
-void playlist_data_get_display_name(char * list_str, playlist_data_t * pldata);
+void playlist_data_get_display_name(char * list_str, size_t list_str_size, playlist_data_t * pldata);
 
 #define PL_IS_SET_FLAG(plist, flag) (plist->flags & flag)
 #define PL_SET_FLAG(plist, flag) (plist->flags |= flag)

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -829,19 +829,19 @@ build_plugin_window(plugin_instance * instance) {
 
 	strcpy(str_inout, "[ ");
 	if (n_ins == 1) {
-		strcat(str_inout, "1 in");
+		arr_strlcat(str_inout, "1 in");
 	} else {
 		arr_snprintf(str_n, "%d ins", n_ins);
-		strcat(str_inout, str_n);
+		arr_strlcat(str_inout, str_n);
 	}
-	strcat(str_inout, " | ");
+	arr_strlcat(str_inout, " | ");
 	if (n_outs == 1) {
-		strcat(str_inout, "1 out");
+		arr_strlcat(str_inout, "1 out");
 	} else {
 		arr_snprintf(str_n, "%d outs", n_outs);
-		strcat(str_inout, str_n);
+		arr_strlcat(str_inout, str_n);
 	}
-	strcat(str_inout, " ]");
+	arr_strlcat(str_inout, " ]");
  
 	widget = gtk_label_new(str_inout);
 	hbox = gtk_hbox_new(FALSE, 0);

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -384,7 +384,7 @@ instantiate(char * filename, int index) {
 		return NULL;
 	}
 
-	strncpy(instance->filename, filename, MAXLEN-1);
+	arr_strlcpy(instance->filename, filename);
 	instance->index = index;
 
 	instance->library = dlopen(filename, RTLD_NOW);
@@ -807,7 +807,7 @@ build_plugin_window(plugin_instance * instance) {
         gtk_box_pack_start(GTK_BOX(hbox), widget, FALSE, FALSE, 0);
 	gtk_box_pack_start(GTK_BOX(upper_vbox), hbox, FALSE, FALSE, 2);
 
-	strncpy(maker, plugin->Maker, MAXLEN-1);
+	arr_strlcpy(maker, plugin->Maker);
 	if ((c = strchr(maker, '<')) != NULL)
 		*c = '\0';
 	widget = gtk_label_new(maker);
@@ -1470,7 +1470,7 @@ foreach_plugin_to_add(GtkTreeModel * model, GtkTreePath * path, GtkTreeIter * it
 	
 	sscanf(str_n_ins, "%d", &n_ins);
 	sscanf(str_n_outs, "%d", &n_outs);
-	strncpy(filename, str_filename, MAXLEN-1);
+	arr_strlcpy(filename, str_filename);
 	sscanf(str_index, "%d", &index);
 	
 	if (((n_ins == 1) && (n_outs == 1)) ||
@@ -2113,7 +2113,7 @@ parse_plugin(xmlDocPtr doc, xmlNodePtr cur) {
                 if ((!xmlStrcmp(cur->name, (const xmlChar *)"filename"))) {
                         key = xmlNodeListGetString(doc, cur->xmlChildrenNode, 1);
                         if (key != NULL)
-                                strncpy(filename, (char *) key, MAXLEN-1);
+                                arr_strlcpy(filename, (char *) key);
                         xmlFree(key);
                         if (filename[0] == '\0') {
                                 fprintf(stderr, "Error in XML aqualung_plugin: "

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -147,7 +147,7 @@ parse_lrdf_data(void) {
 	if ((str = getenv("LADSPA_RDF_PATH"))) {
 		arr_snprintf(lrdf_path, "%s:", str);
 	} else {
-                strncat(lrdf_path, "/usr/local/share/ladspa/rdf:/usr/share/ladspa/rdf:", MAXLEN-1);
+                arr_strlcat(lrdf_path, "/usr/local/share/ladspa/rdf:/usr/share/ladspa/rdf:");
 	}
 
 	for (i = 0; lrdf_path[i] != '\0'; i++) {

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -145,7 +145,7 @@ parse_lrdf_data(void) {
 	lrdf_path[0] = '\0';
 
 	if ((str = getenv("LADSPA_RDF_PATH"))) {
-		snprintf(lrdf_path, MAXLEN-1, "%s:", str);
+		arr_snprintf(lrdf_path, "%s:", str);
 	} else {
                 strncat(lrdf_path, "/usr/local/share/ladspa/rdf:/usr/share/ladspa/rdf:", MAXLEN-1);
 	}
@@ -160,7 +160,7 @@ parse_lrdf_data(void) {
 				int c;
 				
 				for (c = 0; c < n; ++c) {
-					snprintf(fileuri, MAXLEN-1, "file://%s/%s", rdf_path, de[c]->d_name);
+					arr_snprintf(fileuri, "file://%s/%s", rdf_path, de[c]->d_name);
 					if (lrdf_read_file(fileuri)) {
 						fprintf(stderr,
 							"warning: could not parse RDF file: %s\n", fileuri);
@@ -184,7 +184,7 @@ get_ladspa_category(unsigned long plugin_id, char * str) {
 	lrdf_statement * matches1;
 	lrdf_statement * matches2;
 
-        snprintf(buf, 255, "%s%lu", LADSPA_BASE, plugin_id);
+        arr_snprintf(buf, "%s%lu", LADSPA_BASE, plugin_id);
         pattern.subject = buf;
         pattern.predicate = RDF_TYPE;
         pattern.object = 0;
@@ -235,7 +235,7 @@ find_plugins(char * path_entry) {
 	n = scandir(path_entry, &de, so_filter, alphasort);
 	if (n >= 0) {
 		for (c = 0; c < n; ++c) {
-			snprintf(lib_name, MAXLEN-1, "%s/%s", path_entry, de[c]->d_name);
+			arr_snprintf(lib_name, "%s/%s", path_entry, de[c]->d_name);
 			library = dlopen(lib_name, RTLD_LAZY);
 			if (library == NULL) {
 				free(de[c]);
@@ -266,10 +266,10 @@ find_plugins(char * path_entry) {
 				if ((n_ins == 1 && n_outs == 1) || (n_ins == 2 && n_outs == 2)) {
 					
 					get_ladspa_category(descriptor->UniqueID, category);
-					snprintf(id_str, 31, "%ld", descriptor->UniqueID);
-					snprintf(n_ins_str, 31, "%ld", n_ins);
-					snprintf(n_outs_str, 31, "%ld", n_outs);
-					snprintf(c_str, 31, "%d", k);
+					arr_snprintf(id_str, "%ld", descriptor->UniqueID);
+					arr_snprintf(n_ins_str, "%ld", n_ins);
+					arr_snprintf(n_outs_str, "%ld", n_outs);
+					arr_snprintf(c_str, "%d", k);
 					
 					gtk_list_store_append(avail_store, &iter);
 					gtk_list_store_set(avail_store, &iter, 0, id_str,
@@ -831,14 +831,14 @@ build_plugin_window(plugin_instance * instance) {
 	if (n_ins == 1) {
 		strcat(str_inout, "1 in");
 	} else {
-		snprintf(str_n, 15, "%d ins", n_ins);
+		arr_snprintf(str_n, "%d ins", n_ins);
 		strcat(str_inout, str_n);
 	}
 	strcat(str_inout, " | ");
 	if (n_outs == 1) {
 		strcat(str_inout, "1 out");
 	} else {
-		snprintf(str_n, 15, "%d outs", n_outs);
+		arr_snprintf(str_n, "%d outs", n_outs);
 		strcat(str_inout, str_n);
 	}
 	strcat(str_inout, " ]");
@@ -2039,10 +2039,10 @@ save_plugin_data(void) {
 
 		xmlNewTextChild(plugin_node, NULL, (const xmlChar*) "filename", (xmlChar*) instance->filename);
 
-		snprintf(str, 31, "%d", instance->index);
+		arr_snprintf(str, "%d", instance->index);
 		xmlNewTextChild(plugin_node, NULL, (const xmlChar*) "index", (xmlChar*) str);
 
-		snprintf(str, 31, "%d", instance->is_bypassed);
+		arr_snprintf(str, "%d", instance->is_bypassed);
 		xmlNewTextChild(plugin_node, NULL, (const xmlChar*) "is_bypassed", (xmlChar*) str);
 
                 for (k = 0; k < MAX_KNOBS && k < instance->descriptor->PortCount; ++k) {
@@ -2054,10 +2054,10 @@ save_plugin_data(void) {
 
 			port_node = xmlNewTextChild(plugin_node, NULL, (const xmlChar*) "port", NULL);
 
-			snprintf(str, 31, "%d", k);
+			arr_snprintf(str, "%d", k);
 			xmlNewTextChild(port_node, NULL, (const xmlChar*) "index", (xmlChar*) str);
 
-			snprintf(str, 31, "%f", instance->knobs[k]);
+			arr_snprintf(str, "%f", instance->knobs[k]);
 			xmlNewTextChild(port_node, NULL, (const xmlChar*) "value", (xmlChar*) str);
 		}
                 ++i;

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -827,7 +827,7 @@ build_plugin_window(plugin_instance * instance) {
 		}
 	}
 
-	strcpy(str_inout, "[ ");
+	arr_strlcpy(str_inout, "[ ");
 	if (n_ins == 1) {
 		arr_strlcat(str_inout, "1 in");
 	} else {

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -177,7 +177,7 @@ parse_lrdf_data(void) {
 
 
 void
-get_ladspa_category(unsigned long plugin_id, char * str) {
+get_ladspa_category(unsigned long plugin_id, char * str, size_t str_size) {
 
         char buf[256];
         lrdf_statement pattern;
@@ -193,7 +193,7 @@ get_ladspa_category(unsigned long plugin_id, char * str) {
         matches1 = lrdf_matches(&pattern);
 
         if (!matches1) {
-                strncpy(str, "Unknown", MAXLEN-1);
+                g_strlcpy(str, "Unknown", str_size);
 		return;
         }
 
@@ -206,11 +206,11 @@ get_ladspa_category(unsigned long plugin_id, char * str) {
         lrdf_free_statements(matches1);
 
         if (!matches2) {
-                strncpy(str, "Unknown", MAXLEN-1);
+                g_strlcpy(str, "Unknown", str_size);
                 return;
         }
 
-        strncpy(str, matches2->object, MAXLEN-1);
+        g_strlcpy(str, matches2->object, str_size);
         lrdf_free_statements(matches2);
 }
 
@@ -265,7 +265,7 @@ find_plugins(char * path_entry) {
 
 				if ((n_ins == 1 && n_outs == 1) || (n_ins == 2 && n_outs == 2)) {
 					
-					get_ladspa_category(descriptor->UniqueID, category);
+					get_ladspa_category(descriptor->UniqueID, category, CHAR_ARRAY_SIZE(category));
 					arr_snprintf(id_str, "%ld", descriptor->UniqueID);
 					arr_snprintf(n_ins_str, "%ld", n_ins);
 					arr_snprintf(n_outs_str, "%ld", n_outs);

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -521,12 +521,12 @@ activate(plugin_instance * instance) {
 
 
 void
-get_bypassed_name(plugin_instance * instance, char * str) {
+get_bypassed_name(plugin_instance * instance, char * str, size_t str_size) {
 
 	if (instance->is_bypassed) {
-		snprintf(str, MAXLEN-1, "(%s)", instance->descriptor->Name);
+		snprintf(str, str_size, "(%s)", instance->descriptor->Name);
 	} else {
-		strncpy(str, instance->descriptor->Name, MAXLEN-1);
+		g_strlcpy(str, instance->descriptor->Name, str_size);
 	}
 }
 
@@ -594,7 +594,7 @@ plugin_bypassed(GtkWidget * widget, gpointer data) {
 
                 gtk_tree_model_get(GTK_TREE_MODEL(running_store), &iter, 0, &name, 1, &gp_instance, -1);
 		if (instance == (plugin_instance *)gp_instance) {
-			get_bypassed_name(instance, bypassed_name);
+			get_bypassed_name(instance, bypassed_name, CHAR_ARRAY_SIZE(bypassed_name));
 			gtk_list_store_set(running_store, &iter, 0, bypassed_name, -1);
 			return;
 		}
@@ -1488,7 +1488,7 @@ foreach_plugin_to_add(GtkTreeModel * model, GtkTreePath * path, GtkTreeIter * it
 			activate(instance);
 			build_plugin_window(instance);
 			
-			get_bypassed_name(instance, bypassed_name);
+			get_bypassed_name(instance, bypassed_name, CHAR_ARRAY_SIZE(bypassed_name));
 			added_plugin = 1; /* so resort handler will not do any harm */
 			gtk_list_store_append(running_store, &running_iter);
 			gtk_list_store_set(running_store, &running_iter,
@@ -2180,7 +2180,7 @@ parse_plugin(xmlDocPtr doc, xmlNodePtr cur) {
 			instance->is_bypassed = is_bypassed;
 			build_plugin_window(instance);
 			
-			get_bypassed_name(instance, bypassed_name);
+			get_bypassed_name(instance, bypassed_name, CHAR_ARRAY_SIZE(bypassed_name));
 			added_plugin = 1; /* so resort handler will not do any harm */
 			gtk_list_store_append(running_store, &running_iter);
 			gtk_list_store_set(running_store, &running_iter,

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -2024,7 +2024,7 @@ save_plugin_data(void) {
         char str[32];
 
 
-        sprintf(plugin_file, "%s/plugin.xml", options.confdir);
+        arr_snprintf(plugin_file, "%s/plugin.xml", options.confdir);
 
         doc = xmlNewDoc((const xmlChar*) "1.0");
         root = xmlNewNode(NULL, (const xmlChar*) "aqualung_plugin");
@@ -2063,7 +2063,7 @@ save_plugin_data(void) {
                 ++i;
         }
 
-        sprintf(tmpname, "%s/plugin.xml.temp", options.confdir);
+        arr_snprintf(tmpname, "%s/plugin.xml.temp", options.confdir);
         xmlSaveFormatFile(tmpname, doc, 1);
 	xmlFreeDoc(doc);
 
@@ -2202,7 +2202,7 @@ load_plugin_data(void) {
         char plugin_file[MAXLEN];
         FILE * f;
 
-        sprintf(plugin_file, "%s/plugin.xml", options.confdir);
+        arr_snprintf(plugin_file, "%s/plugin.xml", options.confdir);
 
         if ((f = fopen(plugin_file, "rt")) == NULL) {
                 fprintf(stderr, "No plugin.xml -- creating empty one: %s\n", plugin_file);

--- a/src/podcast.c
+++ b/src/podcast.c
@@ -661,7 +661,7 @@ podcast_parse(podcast_t * podcast, GSList ** list) {
 	char * file;
 
 	file = podcast_file_from_url(podcast->url);
-	snprintf(filename, MAXLEN-1, "%s/.%s", podcast->dir, file);
+	arr_snprintf(filename, "%s/.%s", podcast->dir, file);
 	free(file);
 
 	if (podcast_generic_download(podcast, podcast->url, filename, NULL, NULL) < 0) {
@@ -727,7 +727,7 @@ podcast_item_download(podcast_download_t * pd, GSList ** list, GSList * node) {
 
 
 	file = podcast_file_from_url(item->url);
-	snprintf(path, MAXLEN-1, "%s/%s", pd->podcast->dir, file);
+	arr_snprintf(path, "%s/%s", pd->podcast->dir, file);
 	free(file);
 
 	pd->ncurrent++;

--- a/src/podcast.c
+++ b/src/podcast.c
@@ -62,14 +62,14 @@ podcast_new(void) {
 }
 
 void
-podcast_get_display_name(podcast_t * podcast, char * buf) {
+podcast_get_display_name(podcast_t * podcast, char * buf, size_t buf_size) {
 
 	if (podcast->author != NULL && podcast->title != NULL) {
-		snprintf(buf, MAXLEN-1, "%s: %s", podcast->author, podcast->title);
+		snprintf(buf, buf_size, "%s: %s", podcast->author, podcast->title);
 	} else if (podcast->title != NULL) {
-		strncpy(buf, podcast->title, MAXLEN-1);
+		g_strlcpy(buf, podcast->title, buf_size);
 	} else {
-		strncpy(buf, _("Untitled"), MAXLEN-1);
+		g_strlcpy(buf, _("Untitled"), buf_size);
 	}
 }
 

--- a/src/podcast.h
+++ b/src/podcast.h
@@ -75,7 +75,7 @@ typedef struct {
 } podcast_t;
 
 podcast_t * podcast_new(void);
-void podcast_get_display_name(podcast_t * podcast, char * buf);
+void podcast_get_display_name(podcast_t * podcast, char * buf, size_t buf_size);
 podcast_item_t * podcast_item_new(void);
 
 void podcast_free(podcast_t * podcast);

--- a/src/ports.c
+++ b/src/ports.c
@@ -408,7 +408,7 @@ setup_notebook_out(void) {
 				gtk_list_store_append(store_out_nb[n_clients], &iter);
 				gtk_list_store_set(store_out_nb[n_clients], &iter, 0, port_name, -1);
 			}
-			strcpy(client_name_prev, client_name);
+			arr_strlcpy(client_name_prev, client_name);
 			i++;
 		}
 		free(ports_out);

--- a/src/ports.c
+++ b/src/ports.c
@@ -197,7 +197,7 @@ tree_out_nb_selection_changed(GtkObject * tree, gpointer * data) {
 
                 gtk_tree_model_get(model, &iter, 0, &str, -1);
 		label = gtk_label_get_text(GTK_LABEL(nb_out_labels[GPOINTER_TO_INT(data)]));
-		sprintf(fullname, "%s:%s", label, str);
+		arr_snprintf(fullname, "%s:%s", label, str);
 		g_free(str);
 
 		if (out_selector == 0) {

--- a/src/search.c
+++ b/src/search.c
@@ -189,7 +189,7 @@ search_button_clicked(GtkWidget * widget, gpointer data) {
 	}
 
 	if (exactonly) {
-		strcpy(key, key_string);
+		arr_strlcpy(key, key_string);
 	} else {
 		arr_snprintf(key, "*%s*", key_string);
 	}

--- a/src/search.c
+++ b/src/search.c
@@ -191,7 +191,7 @@ search_button_clicked(GtkWidget * widget, gpointer data) {
 	if (exactonly) {
 		strcpy(key, key_string);
 	} else {
-		snprintf(key, MAXLEN-1, "*%s*", key_string);
+		arr_snprintf(key, "*%s*", key_string);
 	}
 
 	pattern = g_pattern_spec_new(key);

--- a/src/search_playlist.c
+++ b/src/search_playlist.c
@@ -208,7 +208,7 @@ search_button_clicked(GtkWidget * widget, gpointer data) {
 	}
 
 	if (exactonly) {
-		strcpy(key, key_string);
+		arr_strlcpy(key, key_string);
 	} else {
 		arr_snprintf(key, "*%s*", key_string);
 	}

--- a/src/search_playlist.c
+++ b/src/search_playlist.c
@@ -150,7 +150,7 @@ search_foreach(playlist_t * pl, GPatternSpec * pattern, GtkTreeIter * list_iter,
 	if (album_node) {
 		arr_snprintf(text, "%s: %s", pldata->artist, pldata->album);
 	} else {
-		playlist_data_get_display_name(text, pldata);
+		playlist_data_get_display_name(text, CHAR_ARRAY_SIZE(text), pldata);
 	}
 
 	if (casesens) {

--- a/src/search_playlist.c
+++ b/src/search_playlist.c
@@ -148,7 +148,7 @@ search_foreach(playlist_t * pl, GPatternSpec * pattern, GtkTreeIter * list_iter,
 
 	gtk_tree_model_get(GTK_TREE_MODEL(pl->store), list_iter, PL_COL_DATA, &pldata, -1);
 	if (album_node) {
-		snprintf(text, MAXLEN-1, "%s: %s", pldata->artist, pldata->album);
+		arr_snprintf(text, "%s: %s", pldata->artist, pldata->album);
 	} else {
 		playlist_data_get_display_name(text, pldata);
 	}
@@ -210,7 +210,7 @@ search_button_clicked(GtkWidget * widget, gpointer data) {
 	if (exactonly) {
 		strcpy(key, key_string);
 	} else {
-		snprintf(key, MAXLEN-1, "*%s*", key_string);
+		arr_snprintf(key, "*%s*", key_string);
 	}
 
 	pattern = g_pattern_spec_new(key);

--- a/src/skin.c
+++ b/src/skin.c
@@ -114,7 +114,7 @@ apply(GtkWidget * widget, gpointer data) {
 	if (gtk_tree_selection_get_selected(skin_select, &model, &iter)) {
 	
 		gtk_tree_model_get(model, &iter, 1, &str, -1);
-		strcpy(options.skin, str);
+		arr_strlcpy(options.skin, str);
 		g_free(str);
 
 		gtk_widget_destroy(skin_window);

--- a/src/skin.c
+++ b/src/skin.c
@@ -64,7 +64,7 @@ apply_skin(char * path) {
 
 	char rcpath[MAXLEN];
 	
-	sprintf(rcpath, "%s/rc", path);
+	arr_snprintf(rcpath, "%s/rc", path);
 	gtk_rc_parse(rcpath);
 
 	toplevel_window_foreach(TOP_WIN_SKIN, apply_skin_foreach);

--- a/src/skin.c
+++ b/src/skin.c
@@ -85,7 +85,7 @@ filter(const struct dirent * de) {
 		return 0;
 	}
 
-	snprintf(dirname, MAXLEN-1, "%s/%s", pdir, de->d_name);
+	arr_snprintf(dirname, "%s/%s", pdir, de->d_name);
 	if (stat(dirname, &st_file) == -1) {
 		fprintf(stderr,
 			"error %s: skin.c/filter(): stat() failed on %s [likely cause: nonexistent file]\n",
@@ -227,7 +227,7 @@ create_skin_window() {
 
 		for (c = 0; c < n; ++c) {
                         gtk_list_store_append(skin_store, &iter);
-                        snprintf(path, MAXLEN - 1, "%s/%s", options.confdir, ent[c]->d_name);
+                        arr_snprintf(path, "%s/%s", options.confdir, ent[c]->d_name);
                         gtk_list_store_set(skin_store, &iter, 0, ent[c]->d_name, 1, path, -1);
 			free(ent[c]);
 		}
@@ -261,7 +261,7 @@ create_skin_window() {
 			if (!found) {
                                 if (strncmp(ent[c]->d_name, "no_skin", MAXLEN-1)) {
                                         gtk_list_store_append(skin_store, &iter);
-                                        snprintf(path, MAXLEN - 1, "%s/%s", AQUALUNG_SKINDIR, ent[c]->d_name);
+                                        arr_snprintf(path, "%s/%s", AQUALUNG_SKINDIR, ent[c]->d_name);
                                         gtk_list_store_set(skin_store, &iter, 0, ent[c]->d_name, 1, path, -1);
                                 }
 			}

--- a/src/store_cdda.c
+++ b/src/store_cdda.c
@@ -1021,23 +1021,23 @@ set_status_bar_info(GtkTreeIter * tree_iter, GtkLabel * statusbar) {
 	switch (depth) {
 	case 3:
 		track_status_bar_info(model, tree_iter, &length);
-		sprintf(str, "%s ", name);
+		arr_snprintf(str, "%s ", name);
 		break;
 	case 2:
 		record_status_bar_info(model, tree_iter, &length, &ntrack, &nrecord);
 		if (nrecord == 0) {
-			sprintf(str, "%s:  %s ", _("CD Audio"), name);
+			arr_snprintf(str, "%s:  %s ", _("CD Audio"), name);
 		} else {
-			sprintf(str, "%s:  %d %s ", name,
-				ntrack, (ntrack == 1) ? _("track") : _("tracks"));
+			arr_snprintf(str, "%s:  %d %s ", name,
+				     ntrack, (ntrack == 1) ? _("track") : _("tracks"));
 		}
 		break;
 	case 1:
 		store_status_bar_info(model, tree_iter, &length, &ntrack, &nrecord, &ndrive);
-		sprintf(str, "%s:  %d %s, %d %s, %d %s ", name,
-			ndrive, (ndrive == 1) ? _("drive") : _("drives"),
-			nrecord, (nrecord == 1) ? _("record") : _("records"),
-			ntrack, (ntrack == 1) ? _("track") : _("tracks"));
+		arr_snprintf(str, "%s:  %d %s, %d %s, %d %s ", name,
+			     ndrive, (ndrive == 1) ? _("drive") : _("drives"),
+			     nrecord, (nrecord == 1) ? _("record") : _("records"),
+			     ntrack, (ntrack == 1) ? _("track") : _("tracks"));
 		break;
 	}
 
@@ -1045,7 +1045,7 @@ set_status_bar_info(GtkTreeIter * tree_iter, GtkLabel * statusbar) {
 
 	if (length > 0.0f) {
 		time2time(length, length_str, CHAR_ARRAY_SIZE(length_str));
-		sprintf(tmp, " [%s] ", length_str);
+		arr_snprintf(tmp, " [%s] ", length_str);
 		strcat(str, tmp);
 	}
 
@@ -1241,11 +1241,11 @@ store_cdda_load_icons(void) {
 
 	char path[MAXLEN];
 
-	sprintf(path, "%s/%s", AQUALUNG_DATADIR, "ms-cdda.png");
+	arr_snprintf(path, "%s/%s", AQUALUNG_DATADIR, "ms-cdda.png");
 	icon_cdda = gdk_pixbuf_new_from_file (path, NULL);
-	sprintf(path, "%s/%s", AQUALUNG_DATADIR, "ms-cdda-disk.png");
+	arr_snprintf(path, "%s/%s", AQUALUNG_DATADIR, "ms-cdda-disk.png");
 	icon_cdda_disc = gdk_pixbuf_new_from_file (path, NULL);
-	sprintf(path, "%s/%s", AQUALUNG_DATADIR, "ms-cdda-nodisk.png");
+	arr_snprintf(path, "%s/%s", AQUALUNG_DATADIR, "ms-cdda-nodisk.png");
 	icon_cdda_nodisc = gdk_pixbuf_new_from_file (path, NULL);
 }
 

--- a/src/store_cdda.c
+++ b/src/store_cdda.c
@@ -633,7 +633,7 @@ cdda_track_addlist_iter(GtkTreeIter iter_track, playlist_t * pl, GtkTreeIter * p
 		gtk_tree_model_get(GTK_TREE_MODEL(pl->store), piter, PL_COL_DATA, &pdata, -1);
 		if (pdata->artist && pdata->album &&
 		    !strcmp(pdata->artist, drive->disc.artist_name) && !strcmp(pdata->album, drive->disc.record_name)) {
-			strcpy(list_str, track_name);
+			arr_strlcpy(list_str, track_name);
 		} else {
 			make_title_string(list_str, CHAR_ARRAY_SIZE(list_str), options.title_format,
 					  drive->disc.artist_name, drive->disc.record_name, track_name);

--- a/src/store_cdda.c
+++ b/src/store_cdda.c
@@ -187,7 +187,7 @@ cdda_drive_info(cdda_drive_t * drive) {
 	cdio_get_drive_cap(cdio, &read_cap, &write_cap, &misc_cap);
 	cdio_destroy(cdio);
 
-	snprintf(str, MAXLEN-1, "%s [%s]", _("Drive info"), cdda_displayed_device_path(drive->device_path));
+	arr_snprintf(str, "%s [%s]", _("Drive info"), cdda_displayed_device_path(drive->device_path));
 
         dialog = gtk_dialog_new_with_buttons(str,
 					     GTK_WINDOW(browser_window),
@@ -699,7 +699,7 @@ cdda_record_addlist_iter(GtkTreeIter iter_record, playlist_t * pl, GtkTreeIter *
 
 		gtk_tree_model_get(GTK_TREE_MODEL(music_store), &iter_record, MS_COL_DATA, &drive, -1);
 
-		snprintf(list_str, MAXLEN-1, "%s: %s", drive->disc.artist_name, drive->disc.record_name);
+		arr_snprintf(list_str, "%s: %s", drive->disc.artist_name, drive->disc.record_name);
 
 		pldata->artist = strdup(drive->disc.artist_name);
 		pldata->album = strdup(drive->disc.record_name);

--- a/src/store_cdda.c
+++ b/src/store_cdda.c
@@ -643,7 +643,7 @@ cdda_track_addlist_iter(GtkTreeIter iter_track, playlist_t * pl, GtkTreeIter * p
 				  drive->disc.record_name, track_name);
 	}
 
-	time2time(data->duration, duration_str);
+	time2time(data->duration, duration_str, CHAR_ARRAY_SIZE(duration_str));
 
 	if ((pldata = playlist_data_new()) == NULL) {
 		return 0;
@@ -727,7 +727,7 @@ cdda_record_addlist_iter(GtkTreeIter iter_record, playlist_t * pl, GtkTreeIter *
 	if (album_mode) {
 		char duration_str[MAXLEN];
 		pldata->duration = record_duration;
-		time2time(record_duration, duration_str);
+		time2time(record_duration, duration_str, CHAR_ARRAY_SIZE(duration_str));
 		gtk_tree_store_set(pl->store, &list_iter, PL_COL_DURA, duration_str, -1);
 	}
 }
@@ -1044,7 +1044,7 @@ set_status_bar_info(GtkTreeIter * tree_iter, GtkLabel * statusbar) {
 	g_free(name);
 
 	if (length > 0.0f) {
-		time2time(length, length_str);
+		time2time(length, length_str, CHAR_ARRAY_SIZE(length_str));
 		sprintf(tmp, " [%s] ", length_str);
 		strcat(str, tmp);
 	}

--- a/src/store_cdda.c
+++ b/src/store_cdda.c
@@ -1046,7 +1046,7 @@ set_status_bar_info(GtkTreeIter * tree_iter, GtkLabel * statusbar) {
 	if (length > 0.0f) {
 		time2time(length, length_str, CHAR_ARRAY_SIZE(length_str));
 		arr_snprintf(tmp, " [%s] ", length_str);
-		strcat(str, tmp);
+		arr_strlcat(str, tmp);
 	}
 
 

--- a/src/store_cdda.c
+++ b/src/store_cdda.c
@@ -635,12 +635,12 @@ cdda_track_addlist_iter(GtkTreeIter iter_track, playlist_t * pl, GtkTreeIter * p
 		    !strcmp(pdata->artist, drive->disc.artist_name) && !strcmp(pdata->album, drive->disc.record_name)) {
 			strcpy(list_str, track_name);
 		} else {
-			make_title_string(list_str, options.title_format, drive->disc.artist_name,
-					  drive->disc.record_name, track_name);
+			make_title_string(list_str, CHAR_ARRAY_SIZE(list_str), options.title_format,
+					  drive->disc.artist_name, drive->disc.record_name, track_name);
 		}
 	} else {
-		make_title_string(list_str, options.title_format, drive->disc.artist_name,
-				  drive->disc.record_name, track_name);
+		make_title_string(list_str, CHAR_ARRAY_SIZE(list_str), options.title_format,
+				  drive->disc.artist_name, drive->disc.record_name, track_name);
 	}
 
 	time2time(data->duration, duration_str, CHAR_ARRAY_SIZE(duration_str));

--- a/src/store_file.c
+++ b/src/store_file.c
@@ -3644,7 +3644,7 @@ set_status_bar_info(GtkTreeIter * tree_iter, GtkLabel * statusbar) {
 		strcpy(tmp, " [N/A] ");
 	}
 
-	strcat(str, tmp);
+	arr_strlcat(str, tmp);
 
 	if (options.ms_statusbar_show_size) {
 		if (size > 1024 * 1024) {
@@ -3656,7 +3656,7 @@ set_status_bar_info(GtkTreeIter * tree_iter, GtkLabel * statusbar) {
 		} else {
 			strcpy(tmp, " (N/A) ");
 		}
-		strcat(str, tmp);
+		arr_strlcat(str, tmp);
 	}
 
 	gtk_label_set_text(statusbar, str);

--- a/src/store_file.c
+++ b/src/store_file.c
@@ -1371,10 +1371,12 @@ track_addlist_iter(GtkTreeIter iter_track, playlist_t * pl,
 		    !strcmp(pdata->artist, artist_name) && !strcmp(pdata->album, record_name)) {
 			strcpy(list_str, track_name);
 		} else {
-			make_title_string(list_str, options.title_format, artist_name, record_name, track_name);
+			make_title_string(list_str, CHAR_ARRAY_SIZE(list_str), options.title_format,
+					  artist_name, record_name, track_name);
 		}
 	} else {
-		make_title_string(list_str, options.title_format, artist_name, record_name, track_name);
+		make_title_string(list_str, CHAR_ARRAY_SIZE(list_str), options.title_format,
+				  artist_name, record_name, track_name);
 	}
 
 	if (options.rva_is_enabled) {
@@ -4880,7 +4882,8 @@ store_model_func(GtkTreeModel * model, GtkTreeIter iter, char**name, char**file)
 	gtk_tree_model_iter_parent(model, &iter_artist, &iter_record);
 	gtk_tree_model_get(model, &iter_artist, MS_COL_NAME, &artist_name, -1);
 
-	make_title_string(buf, options.title_format, artist_name, record_name, track_name);
+	make_title_string(buf, CHAR_ARRAY_SIZE(buf), options.title_format,
+			  artist_name, record_name, track_name);
 
 	*name = strndup(buf, MAXLEN-1);
 	*file = strdup(data->file);

--- a/src/store_file.c
+++ b/src/store_file.c
@@ -838,15 +838,15 @@ add_record_dialog(char * name, size_t name_size, char * sort, size_t sort_size, 
 				gtk_tree_model_iter_next(GTK_TREE_MODEL(store), &iter);
 
 				filename = g_filename_from_utf8(str, -1, NULL, NULL, NULL);
+				(*strings)[i] = strdup(filename);
 
-				if (!((*strings)[i] = calloc(strlen(filename)+1, sizeof(char)))) {
-					fprintf(stderr, "add_record_dialog(): calloc error\n");
-					return 0;
-				}
-
-				strcpy((*strings)[i], filename);
 				g_free(str);
 				g_free(filename);
+
+				if (!(*strings)[i]) {
+					fprintf(stderr, "add_record_dialog(): strdup error\n");
+					return 0;
+				}
 			}
 			(*strings)[i] = NULL;
 		}
@@ -1369,7 +1369,7 @@ track_addlist_iter(GtkTreeIter iter_track, playlist_t * pl,
 		gtk_tree_model_get(GTK_TREE_MODEL(pl->store), piter, PL_COL_DATA, &pdata, -1);
 		if (pdata->artist && pdata->album && artist_name && record_name &&
 		    !strcmp(pdata->artist, artist_name) && !strcmp(pdata->album, record_name)) {
-			strcpy(list_str, track_name);
+			arr_strlcpy(list_str, track_name);
 		} else {
 			make_title_string(list_str, CHAR_ARRAY_SIZE(list_str), options.title_format,
 					  artist_name, record_name, track_name);
@@ -3641,7 +3641,7 @@ set_status_bar_info(GtkTreeIter * tree_iter, GtkLabel * statusbar) {
 		time2time(length, length_str, CHAR_ARRAY_SIZE(length_str));
 		arr_snprintf(tmp, " [%s] ", length_str);
 	} else {
-		strcpy(tmp, " [N/A] ");
+		arr_strlcpy(tmp, " [N/A] ");
 	}
 
 	arr_strlcat(str, tmp);

--- a/src/store_file.c
+++ b/src/store_file.c
@@ -2351,7 +2351,7 @@ record__add_cb(gpointer user_data) {
 
 			if (strings) {
 				for (i = 0; strings[i] != NULL; i++) {
-					sprintf(str_n, "%02d", i+1);
+					arr_snprintf(str_n, "%02d", i+1);
 					str = strings[i];
 					while (strstr(str, "/")) {
 						str = strstr(str, "/") + 1;
@@ -3600,33 +3600,33 @@ set_status_bar_info(GtkTreeIter * tree_iter, GtkLabel * statusbar) {
 	case 4:
 		track_status_bar_info(model, tree_iter, &size, &length);
 		ntrack = 1;
-		sprintf(str, "%s ", name);
+		arr_snprintf(str, "%s ", name);
 		break;
 	case 3:
 		gtk_tree_model_get(model, tree_iter, MS_COL_DATA, &record_data, -1);
 		record_status_bar_info(model, tree_iter, &size, &length, &ntrack);
 		if (is_valid_year(record_data->year)) {
-			sprintf(str, "%s (%d):  %d %s ", name, record_data->year,
-				ntrack, (ntrack == 1) ? _("track") : _("tracks"));
+			arr_snprintf(str, "%s (%d):  %d %s ", name, record_data->year,
+				     ntrack, (ntrack == 1) ? _("track") : _("tracks"));
 		} else {
-			sprintf(str, "%s:  %d %s ", name,
-				ntrack, (ntrack == 1) ? _("track") : _("tracks"));
+			arr_snprintf(str, "%s:  %d %s ", name,
+				     ntrack, (ntrack == 1) ? _("track") : _("tracks"));
 		}
 
 		break;
 	case 2:
 		artist_status_bar_info(model, tree_iter, &size, &length, &ntrack, &nrecord);
-		sprintf(str, "%s:  %d %s, %d %s ", name,
-			nrecord, (nrecord == 1) ? _("record") : _("records"),
-			ntrack, (ntrack == 1) ? _("track") : _("tracks"));
+		arr_snprintf(str, "%s:  %d %s, %d %s ", name,
+			     nrecord, (nrecord == 1) ? _("record") : _("records"),
+			     ntrack, (ntrack == 1) ? _("track") : _("tracks"));
 		break;
 	case 1:
 		gtk_tree_model_get(model, tree_iter, MS_COL_DATA, &store_data, -1);
 		store_status_bar_info(model, tree_iter, &size, &length, &ntrack, &nrecord, &nartist);
-		sprintf(str, "%s:  %d %s, %d %s, %d %s ", store_data->dirty ? name+1 : name,
-			nartist, (nartist == 1) ? _("artist") : _("artists"),
-			nrecord, (nrecord == 1) ? _("record") : _("records"),
-			ntrack, (ntrack == 1) ? _("track") : _("tracks"));
+		arr_snprintf(str, "%s:  %d %s, %d %s, %d %s ", store_data->dirty ? name+1 : name,
+			     nartist, (nartist == 1) ? _("artist") : _("artists"),
+			     nrecord, (nrecord == 1) ? _("record") : _("records"),
+			     ntrack, (ntrack == 1) ? _("track") : _("tracks"));
 		break;
 	}
 
@@ -3634,7 +3634,7 @@ set_status_bar_info(GtkTreeIter * tree_iter, GtkLabel * statusbar) {
 
 	if (length > 0.0f || ntrack == 0) {
 		time2time(length, length_str, CHAR_ARRAY_SIZE(length_str));
-		sprintf(tmp, " [%s] ", length_str);
+		arr_snprintf(tmp, " [%s] ", length_str);
 	} else {
 		strcpy(tmp, " [N/A] ");
 	}
@@ -3643,11 +3643,11 @@ set_status_bar_info(GtkTreeIter * tree_iter, GtkLabel * statusbar) {
 
 	if (options.ms_statusbar_show_size) {
 		if (size > 1024 * 1024) {
-			sprintf(tmp, " (%.1f GB) ", size / (1024 * 1024));
+			arr_snprintf(tmp, " (%.1f GB) ", size / (1024 * 1024));
 		} else if (size > 1024) {
-			sprintf(tmp, " (%.1f MB) ", size / 1024);
+			arr_snprintf(tmp, " (%.1f MB) ", size / 1024);
 		} else if (size > 0 || ntrack == 0) {
-			sprintf(tmp, " (%.1f KB) ", size);
+			arr_snprintf(tmp, " (%.1f KB) ", size);
 		} else {
 			strcpy(tmp, " (N/A) ");
 		}
@@ -4416,11 +4416,11 @@ store_file_load_icons(void) {
 
 	char path[MAXLEN];
 
-	sprintf(path, "%s/%s", AQUALUNG_DATADIR, "ms-artist.png");
+	arr_snprintf(path, "%s/%s", AQUALUNG_DATADIR, "ms-artist.png");
 	icon_artist = gdk_pixbuf_new_from_file (path, NULL);
-	sprintf(path, "%s/%s", AQUALUNG_DATADIR, "ms-record.png");
+	arr_snprintf(path, "%s/%s", AQUALUNG_DATADIR, "ms-record.png");
 	icon_record = gdk_pixbuf_new_from_file (path, NULL);
-	sprintf(path, "%s/%s", AQUALUNG_DATADIR, "ms-track.png");
+	arr_snprintf(path, "%s/%s", AQUALUNG_DATADIR, "ms-track.png");
 	icon_track = gdk_pixbuf_new_from_file (path, NULL);
 }
 

--- a/src/store_file.c
+++ b/src/store_file.c
@@ -449,7 +449,7 @@ browse_button_store_clicked(GtkButton * button, gpointer data) {
 				GTK_FILE_CHOOSER_ACTION_SAVE,
 				FILE_CHOOSER_FILTER_STORE,
 				(GtkWidget *)data,
-				options.storedir);
+				options.storedir, CHAR_ARRAY_SIZE(options.storedir));
 }
 
 int
@@ -704,7 +704,7 @@ browse_button_record_clicked(GtkButton * button, gpointer data) {
 			      GTK_FILE_CHOOSER_ACTION_OPEN,
 			      FILE_CHOOSER_FILTER_AUDIO,
 			      TRUE,
-			      options.audiodir);
+			      options.audiodir, CHAR_ARRAY_SIZE(options.audiodir));
 
 	for (node = lfiles; node; node = node->next) {
 
@@ -935,7 +935,7 @@ browse_button_track_clicked(GtkButton * button, gpointer data) {
 				GTK_FILE_CHOOSER_ACTION_OPEN,
 				FILE_CHOOSER_FILTER_AUDIO,
 				(GtkWidget *)data,
-				options.audiodir);
+				options.audiodir, CHAR_ARRAY_SIZE(options.audiodir));
 }
 
 

--- a/src/store_file.c
+++ b/src/store_file.c
@@ -3654,7 +3654,7 @@ set_status_bar_info(GtkTreeIter * tree_iter, GtkLabel * statusbar) {
 		} else if (size > 0 || ntrack == 0) {
 			arr_snprintf(tmp, " (%.1f KB) ", size);
 		} else {
-			strcpy(tmp, " (N/A) ");
+			arr_strlcpy(tmp, " (N/A) ");
 		}
 		arr_strlcat(str, tmp);
 	}

--- a/src/store_file.c
+++ b/src/store_file.c
@@ -1063,9 +1063,9 @@ edit_track_dialog(char * name, char * sort, track_data_t * data) {
 	insert_label_entry(table, _("Duration:"), &duration_entry, str, 3, 4, FALSE);
 
 	if (data->volume <= 0.1f) {
-		snprintf(str, MAXLEN-1, "%.1f dBFS", data->volume);
+		arr_snprintf(str, "%.1f dBFS", data->volume);
 	} else {
-		snprintf(str, MAXLEN-1, _("Unmeasured"));
+		arr_snprintf(str, _("Unmeasured"));
 	}
 	insert_label_entry(table, _("Volume level:"), &volume_entry, str, 4, 5, FALSE);
 
@@ -1295,7 +1295,7 @@ generic_remove_cb(char * title, int (* remove_cb)(GtkTreeIter *)) {
 			char text[MAXLEN];
 
 			gtk_tree_model_get(model, &iter, MS_COL_NAME, &name, -1);
-			snprintf(text, MAXLEN-1, _("Really remove \"%s\" from the Music Store?"), name);
+			arr_snprintf(text, _("Really remove \"%s\" from the Music Store?"), name);
 			g_free(name);
 
 			ok = confirm_dialog(title, text);
@@ -1503,7 +1503,7 @@ record_addlist_iter(GtkTreeIter iter_record, playlist_t * pl,
 		gtk_tree_model_iter_parent(GTK_TREE_MODEL(music_store), &iter_artist, &iter_record);
 		gtk_tree_model_get(GTK_TREE_MODEL(music_store), &iter_artist, MS_COL_NAME, &artist_name, -1);
 
-		snprintf(list_str, MAXLEN-1, "%s: %s", artist_name, record_name);
+		arr_snprintf(list_str, "%s: %s", artist_name, record_name);
 
 		pldata->artist = strdup(artist_name);
 		pldata->album = strdup(record_name);
@@ -2031,8 +2031,8 @@ store__remove_cb(gpointer user_data) {
 		strncpy(name, pname, MAXLEN-1);
                 g_free(pname);
 
-		snprintf(text, MAXLEN-1, _("Really remove store \"%s\" from the Music Store?"),
-			 (data->dirty) ? (name + 1) : (name));
+		arr_snprintf(text, _("Really remove store \"%s\" from the Music Store?"),
+			     (data->dirty) ? (name + 1) : (name));
 		if (confirm_dialog(_("Remove Store"), text)) {
 
 			char * file = strdup(data->file);
@@ -3313,7 +3313,7 @@ record_batch_tag_set_from_iter(GtkTreeIter * iter) {
 	g_free(str);
 
 	gtk_tree_model_get(GTK_TREE_MODEL(music_store), iter, MS_COL_DATA, &data, -1);
-	snprintf(year_tag, MAXLEN-1, "%d", data->year);
+	arr_snprintf(year_tag, "%d", data->year);
 }
 
 gboolean
@@ -4098,7 +4098,7 @@ save_track(xmlDocPtr doc, xmlNodePtr node_track, GtkTreeIter * iter_track,
 	}
 
 	if (data->size != 0) {
-		snprintf(str, 31, "%u", data->size);
+		arr_snprintf(str, "%u", data->size);
 		xmlNewTextChild(node, NULL, (const xmlChar *) "size", (const xmlChar *) str);
 	}
 
@@ -4107,22 +4107,22 @@ save_track(xmlDocPtr doc, xmlNodePtr node_track, GtkTreeIter * iter_track,
 	}
 
 	if (data->duration != 0.0f) {
-		snprintf(str, 31, "%.1f", data->duration);
+		arr_snprintf(str, "%.1f", data->duration);
 		xmlNewTextChild(node, NULL, (const xmlChar *) "duration", (const xmlChar *) str);
 	}
 
 	if (data->volume <= 0.1f) {
-		snprintf(str, 31, "%.1f", data->volume);
+		arr_snprintf(str, "%.1f", data->volume);
 		xmlNewTextChild(node, NULL, (const xmlChar *) "volume", (const xmlChar *) str);
 	}
 
 	if (data->rva != 0.0f) {
-		snprintf(str, 31, "%.1f", data->rva);
+		arr_snprintf(str, "%.1f", data->rva);
 		xmlNewTextChild(node, NULL, (const xmlChar *) "rva", (const xmlChar *) str);
 	}
 
 	if (data->use_rva) {
-		snprintf(str, 31, "%d", data->use_rva);
+		arr_snprintf(str, "%d", data->use_rva);
 		xmlNewTextChild(node, NULL, (const xmlChar *) "use_rva", (const xmlChar *) str);
 	}
 
@@ -4160,7 +4160,7 @@ save_record(xmlDocPtr doc, xmlNodePtr node_record, GtkTreeIter * iter_record,
 	}
 	if (data->year != 0) {
 		char str[32];
-		snprintf(str, 31, "%d", data->year);
+		arr_snprintf(str, "%d", data->year);
 		xmlNewTextChild(node, NULL, (const xmlChar *) "year", (const xmlChar *) str);
 	}
 

--- a/src/store_file.c
+++ b/src/store_file.c
@@ -500,7 +500,7 @@ add_store_dialog(char * name, store_data_t ** data) {
 
 		(*data)->type = STORE_TYPE_FILE;
 
-		normalize_filename(pfile, file);
+		normalize_filename(pfile, file, CHAR_ARRAY_SIZE(file));
 		free_strdup(&(*data)->file, file);
 
 		strncpy(options.storedir, file, MAXLEN-1);
@@ -991,7 +991,7 @@ add_track_dialog(char * name, char * sort, track_data_t ** data) {
 
                 strcpy(sort, gtk_entry_get_text(GTK_ENTRY(sort_entry)));
 
-		normalize_filename(pfile, file);
+		normalize_filename(pfile, file, CHAR_ARRAY_SIZE(file));
 		free_strdup(&(*data)->file, file);
 
 		gtk_text_buffer_get_iter_at_offset(GTK_TEXT_BUFFER(buffer), &iter_start, 0);
@@ -1124,7 +1124,7 @@ edit_track_dialog(char * name, char * sort, track_data_t * data) {
 
                 strcpy(sort, gtk_entry_get_text(GTK_ENTRY(sort_entry)));
 
-		normalize_filename(pfile, file);
+		normalize_filename(pfile, file, CHAR_ARRAY_SIZE(file));
 		free_strdup(&data->file, file);
 
 		gtk_text_buffer_get_iter_at_offset(GTK_TEXT_BUFFER(buffer), &iter_start, 0);

--- a/src/store_file.c
+++ b/src/store_file.c
@@ -1059,7 +1059,7 @@ edit_track_dialog(char * name, char * sort, track_data_t * data) {
 				  browse_button_track_clicked);
 	g_free(utf8);
 
-	time2time(data->duration, str);
+	time2time(data->duration, str, CHAR_ARRAY_SIZE(str));
 	insert_label_entry(table, _("Duration:"), &duration_entry, str, 3, 4, FALSE);
 
 	if (data->volume <= 0.1f) {
@@ -1395,7 +1395,7 @@ track_addlist_iter(GtkTreeIter iter_track, playlist_t * pl,
 		}
 	}
 
-	time2time(data->duration, duration_str);
+	time2time(data->duration, duration_str, CHAR_ARRAY_SIZE(duration_str));
 	voladj2str(voladj, voladj_str, CHAR_ARRAY_SIZE(voladj_str));
 
 	if ((pldata = playlist_data_new()) == NULL) {
@@ -1535,7 +1535,7 @@ record_addlist_iter(GtkTreeIter iter_record, playlist_t * pl,
 	if (album_mode) {
 		char duration_str[MAXLEN];
 		pldata->duration = record_duration;
-		time2time(record_duration, duration_str);
+		time2time(record_duration, duration_str, CHAR_ARRAY_SIZE(duration_str));
 		gtk_tree_store_set(pl->store, &list_iter, PL_COL_DURA, duration_str, -1);
 	}
 }
@@ -3633,7 +3633,7 @@ set_status_bar_info(GtkTreeIter * tree_iter, GtkLabel * statusbar) {
 	g_free(name);
 
 	if (length > 0.0f || ntrack == 0) {
-		time2time(length, length_str);
+		time2time(length, length_str, CHAR_ARRAY_SIZE(length_str));
 		sprintf(tmp, " [%s] ", length_str);
 	} else {
 		strcpy(tmp, " [N/A] ");

--- a/src/store_file.c
+++ b/src/store_file.c
@@ -1396,7 +1396,7 @@ track_addlist_iter(GtkTreeIter iter_track, playlist_t * pl,
 	}
 
 	time2time(data->duration, duration_str);
-	voladj2str(voladj, voladj_str);
+	voladj2str(voladj, voladj_str, CHAR_ARRAY_SIZE(voladj_str));
 
 	if ((pldata = playlist_data_new()) == NULL) {
 		return 0;

--- a/src/store_file.c
+++ b/src/store_file.c
@@ -503,7 +503,7 @@ add_store_dialog(char * name, size_t name_size, store_data_t ** data) {
 		normalize_filename(pfile, file, CHAR_ARRAY_SIZE(file));
 		free_strdup(&(*data)->file, file);
 
-		strncpy(options.storedir, file, MAXLEN-1);
+		arr_strlcpy(options.storedir, file);
 		gtk_text_buffer_get_iter_at_offset(GTK_TEXT_BUFFER(buffer), &iter_start, 0);
 		gtk_text_buffer_get_iter_at_offset(GTK_TEXT_BUFFER(buffer), &iter_end, -1);
 		free_strdup(&(*data)->comment, gtk_text_buffer_get_text(GTK_TEXT_BUFFER(buffer),
@@ -1938,7 +1938,7 @@ store__edit_cb(gpointer user_data) {
 			return;
 		}
 
-		strncpy(name, pname, MAXLEN-1);
+		arr_strlcpy(name, pname);
 		g_free(pname);
 
 		offset = ((data->dirty) ? 1 : 0);
@@ -2032,7 +2032,7 @@ store__remove_cb(gpointer user_data) {
 				   MS_COL_NAME, &pname,
 				   MS_COL_DATA, &data, -1);
 
-		strncpy(name, pname, MAXLEN-1);
+		arr_strlcpy(name, pname);
                 g_free(pname);
 
 		arr_snprintf(text, _("Really remove store \"%s\" from the Music Store?"),
@@ -2189,8 +2189,8 @@ artist__edit_cb(gpointer user_data) {
 				   MS_COL_SORT, &psort,
 				   MS_COL_DATA, &data, -1);
 
-		strncpy(name, pname, MAXLEN-1);
-		strncpy(sort, psort, MAXLEN-1);
+		arr_strlcpy(name, pname);
+		arr_strlcpy(sort, psort);
                 g_free(pname);
                 g_free(psort);
 
@@ -2421,8 +2421,8 @@ record__edit_cb(gpointer user_data) {
 				   MS_COL_SORT, &psort,
 				   MS_COL_DATA, &data, -1);
 
-		strncpy(name, pname, MAXLEN-1);
-		strncpy(sort, psort, MAXLEN-1);
+		arr_strlcpy(name, pname);
+		arr_strlcpy(sort, psort);
                 g_free(pname);
                 g_free(psort);
 
@@ -2645,8 +2645,8 @@ track__edit_cb(gpointer user_data) {
 				   MS_COL_SORT, &psort,
 				   MS_COL_DATA, &data, -1);
 
-                strncpy(name, pname, MAXLEN-1);
-                strncpy(sort, psort, MAXLEN-1);
+                arr_strlcpy(name, pname);
+                arr_strlcpy(sort, psort);
                 g_free(pname);
                 g_free(psort);
 
@@ -2764,12 +2764,12 @@ track_export(GtkTreeIter * iter_track, export_t * export, char * _artist, char *
 				   MS_COL_NAME, &tmp,
 				   MS_COL_DATA, &record_data, -1);
 
-		strncpy(album, tmp, MAXLEN-1);
+		arr_strlcpy(album, tmp);
 		g_free(tmp);
 
 		year = record_data->year;
 	} else {
-		strncpy(album, _album, MAXLEN-1);
+		arr_strlcpy(album, _album);
 	}
 
 	if (_artist == NULL) {
@@ -2779,10 +2779,10 @@ track_export(GtkTreeIter * iter_track, export_t * export, char * _artist, char *
 		gtk_tree_model_get(GTK_TREE_MODEL(music_store), &iter_artist,
 				   MS_COL_NAME, &tmp, -1);
 
-		strncpy(artist, tmp, MAXLEN-1);
+		arr_strlcpy(artist, tmp);
 		g_free(tmp);
 	} else {
-		strncpy(artist, _artist, MAXLEN-1);
+		arr_strlcpy(artist, _artist);
 	}
 
 	export_append_item(export, track_data->file, artist, album, title, year, no);
@@ -2813,10 +2813,10 @@ record_export(GtkTreeIter * iter_record, export_t * export, char * _artist) {
 		gtk_tree_model_get(GTK_TREE_MODEL(music_store), &iter_artist,
 				   MS_COL_NAME, &tmp, -1);
 
-		strncpy(artist, tmp, MAXLEN-1);
+		arr_strlcpy(artist, tmp);
 		g_free(tmp);
 	} else {
-		strncpy(artist, _artist, MAXLEN-1);
+		arr_strlcpy(artist, _artist);
 	}
 
 	i = 0;
@@ -3275,22 +3275,22 @@ track_batch_tag(gpointer data) {
 			   MS_COL_SORT, &track,
 			   MS_COL_DATA, &track_data, -1);
 
-	strncpy(ptag->artist, artist_tag, MAXLEN-1);
-	strncpy(ptag->album, album_tag, MAXLEN-1);
-	strncpy(ptag->year, year_tag, MAXLEN-1);
-	strncpy(ptag->title, title, MAXLEN-1);
+	arr_strlcpy(ptag->artist, artist_tag);
+	arr_strlcpy(ptag->album, album_tag);
+	arr_strlcpy(ptag->year, year_tag);
+	arr_strlcpy(ptag->title, title);
 	if (sscanf(track, "%d", &ptag->trackno) < 1) {
 		ptag->trackno = -1;
 	}
 
 	if (track_data->file != NULL) {
-		strncpy(ptag->filename, track_data->file, MAXLEN-1);
+		arr_strlcpy(ptag->filename, track_data->file);
 	} else {
 		ptag->filename[0] = '\0';
 	}
 
 	if (track_data->comment != NULL) {
-		strncpy(ptag->comment, track_data->comment, MAXLEN-1);
+		arr_strlcpy(ptag->comment, track_data->comment);
 	} else {
 		ptag->comment[0] = '\0';
 	}
@@ -3314,7 +3314,7 @@ record_batch_tag_set_from_iter(GtkTreeIter * iter) {
 	record_data_t * data;
 
 	gtk_tree_model_get(GTK_TREE_MODEL(music_store), iter, MS_COL_NAME, &str, -1);
-	strncpy(album_tag, str, MAXLEN-1);
+	arr_strlcpy(album_tag, str);
 	g_free(str);
 
 	gtk_tree_model_get(GTK_TREE_MODEL(music_store), iter, MS_COL_DATA, &data, -1);
@@ -3349,7 +3349,7 @@ artist_batch_tag_set_from_iter(GtkTreeIter * iter) {
 
 	char * str;
 	gtk_tree_model_get(GTK_TREE_MODEL(music_store), iter, MS_COL_NAME, &str, -1);
-	strncpy(artist_tag, str, MAXLEN-1);
+	arr_strlcpy(artist_tag, str);
 	g_free(str);
 }
 
@@ -3732,7 +3732,7 @@ parse_track(xmlDocPtr doc, xmlNodePtr cur, GtkTreeIter * iter_record, char * sto
 		if ((!xmlStrcmp(cur->name, (const xmlChar *)"name"))) {
 			key = xmlNodeListGetString(doc, cur->xmlChildrenNode, 1);
 			if (key != NULL) {
-				strncpy(name, (char *) key, MAXLEN-1);
+				arr_strlcpy(name, (char *) key);
 				xmlFree(key);
 			}
 			if (name[0] == '\0') {
@@ -3742,7 +3742,7 @@ parse_track(xmlDocPtr doc, xmlNodePtr cur, GtkTreeIter * iter_record, char * sto
 		} else if ((!xmlStrcmp(cur->name, (const xmlChar *)"sort_name"))) {
 			key = xmlNodeListGetString(doc, cur->xmlChildrenNode, 1);
 			if (key != NULL) {
-				strncpy(sort, (char *) key, MAXLEN-1);
+				arr_strlcpy(sort, (char *) key);
 				xmlFree(key);
 			}
 			gtk_tree_store_set(music_store, &iter_track, MS_COL_SORT, sort, -1);
@@ -3844,7 +3844,7 @@ parse_record(xmlDocPtr doc, xmlNodePtr cur, GtkTreeIter * iter_artist, char * st
 		if ((!xmlStrcmp(cur->name, (const xmlChar *)"name"))) {
 			key = xmlNodeListGetString(doc, cur->xmlChildrenNode, 1);
 			if (key != NULL) {
-				strncpy(name, (char *) key, MAXLEN-1);
+				arr_strlcpy(name, (char *) key);
 				xmlFree(key);
 			}
 			if (name[0] == '\0') {
@@ -3855,7 +3855,7 @@ parse_record(xmlDocPtr doc, xmlNodePtr cur, GtkTreeIter * iter_artist, char * st
 		} else if ((!xmlStrcmp(cur->name, (const xmlChar *)"sort_name"))) {
 			key = xmlNodeListGetString(doc, cur->xmlChildrenNode, 1);
 			if (key != NULL) {
-				strncpy(sort, (char *) key, MAXLEN-1);
+				arr_strlcpy(sort, (char *) key);
 				/* parse year from sort key if otherwise not set */
 				if (is_valid_year(atoi(sort)) && !is_valid_year(data->year)) {
 					data->year = atoi(sort);
@@ -3916,7 +3916,7 @@ parse_artist(xmlDocPtr doc, xmlNodePtr cur, GtkTreeIter * iter_store, char * sto
 		if ((!xmlStrcmp(cur->name, (const xmlChar *)"name"))) {
 			key = xmlNodeListGetString(doc, cur->xmlChildrenNode, 1);
 			if (key != NULL) {
-				strncpy(name, (char *) key, MAXLEN-1);
+				arr_strlcpy(name, (char *) key);
 				xmlFree(key);
 			}
 			if (name[0] == '\0') {
@@ -3927,7 +3927,7 @@ parse_artist(xmlDocPtr doc, xmlNodePtr cur, GtkTreeIter * iter_store, char * sto
 		} else if ((!xmlStrcmp(cur->name, (const xmlChar *)"sort_name"))) {
 			key = xmlNodeListGetString(doc, cur->xmlChildrenNode, 1);
 			if (key != NULL) {
-				strncpy(sort, (char *) key, MAXLEN-1);
+				arr_strlcpy(sort, (char *) key);
 				xmlFree(key);
 			}
 			gtk_tree_store_set(music_store, &iter_artist, MS_COL_SORT, sort, -1);
@@ -4019,7 +4019,7 @@ store_file_load(char * store_file, char * sort) {
 		if ((!xmlStrcmp(cur->name, (const xmlChar *)"name"))) {
 			key = xmlNodeListGetString(doc, cur->xmlChildrenNode, 1);
 			if (key != NULL) {
-				strncpy(name, (char *) key, MAXLEN-1);
+				arr_strlcpy(name, (char *) key);
 				xmlFree(key);
 			}
 			if (name[0] == '\0') {

--- a/src/store_file.c
+++ b/src/store_file.c
@@ -453,7 +453,7 @@ browse_button_store_clicked(GtkButton * button, gpointer data) {
 }
 
 int
-add_store_dialog(char * name, store_data_t ** data) {
+add_store_dialog(char * name, size_t name_size, store_data_t ** data) {
 
 	GtkWidget * dialog;
 	GtkWidget * table;
@@ -481,7 +481,7 @@ add_store_dialog(char * name, store_data_t ** data) {
 		const char * pfile = g_filename_from_utf8(gtk_entry_get_text(GTK_ENTRY(file_entry)), -1, NULL, NULL, NULL);
 		char file[MAXLEN];
 
-		strncpy(name, gtk_entry_get_text(GTK_ENTRY(name_entry)), MAXLEN-1);
+		g_strlcpy(name, gtk_entry_get_text(GTK_ENTRY(name_entry)), name_size);
 		if (name[0] == '\0') {
 			gtk_widget_grab_focus(name_entry);
 			goto display;
@@ -518,7 +518,7 @@ add_store_dialog(char * name, store_data_t ** data) {
 
 
 int
-edit_store_dialog(char * name, store_data_t * data) {
+edit_store_dialog(char * name, size_t name_size, store_data_t * data) {
 
 	GtkWidget * dialog;
 	GtkWidget * content_area;
@@ -559,7 +559,7 @@ edit_store_dialog(char * name, store_data_t * data) {
 
         if (aqualung_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
 
-                strcpy(name, gtk_entry_get_text(GTK_ENTRY(name_entry)));
+		g_strlcpy(name, gtk_entry_get_text(GTK_ENTRY(name_entry)), name_size);
 
 		if (name[0] == '\0') {
 			gtk_widget_grab_focus(name_entry);
@@ -588,7 +588,7 @@ entry_copy_text(GtkEntry * entry, gpointer data) {
 }
 
 int
-add_artist_dialog(char * name, char * sort, artist_data_t ** data) {
+add_artist_dialog(char * name, size_t name_size, char * sort, size_t sort_size, artist_data_t ** data) {
 
 	GtkWidget * dialog;
 	GtkWidget * table;
@@ -615,14 +615,14 @@ add_artist_dialog(char * name, char * sort, artist_data_t ** data) {
 
         if (aqualung_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
 
-                strcpy(name, gtk_entry_get_text(GTK_ENTRY(name_entry)));
+		g_strlcpy(name, gtk_entry_get_text(GTK_ENTRY(name_entry)), name_size);
 
 		if (name[0] == '\0') {
 			gtk_widget_grab_focus(name_entry);
 			goto display;
 		}
 
-                strcpy(sort, gtk_entry_get_text(GTK_ENTRY(sort_entry)));
+		g_strlcpy(sort, gtk_entry_get_text(GTK_ENTRY(sort_entry)), sort_size);
 
 		if ((*data = (artist_data_t *)calloc(1, sizeof(artist_data_t))) == NULL) {
 			fprintf(stderr, "add_artist_dialog: calloc error\n");
@@ -643,7 +643,7 @@ add_artist_dialog(char * name, char * sort, artist_data_t ** data) {
 
 
 int
-edit_artist_dialog(char * name, char * sort, artist_data_t * data) {
+edit_artist_dialog(char * name, size_t name_size, char * sort, size_t sort_size, artist_data_t * data) {
 
 	GtkWidget * dialog;
 	GtkWidget * table;
@@ -670,14 +670,14 @@ edit_artist_dialog(char * name, char * sort, artist_data_t * data) {
 
         if (aqualung_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
 
-                strcpy(name, gtk_entry_get_text(GTK_ENTRY(name_entry)));
+		g_strlcpy(name, gtk_entry_get_text(GTK_ENTRY(name_entry)), name_size);
 
 		if (name[0] == '\0') {
 			gtk_widget_grab_focus(name_entry);
 			goto display;
 		}
 
-                strcpy(sort, gtk_entry_get_text(GTK_ENTRY(sort_entry)));
+		g_strlcpy(sort, gtk_entry_get_text(GTK_ENTRY(sort_entry)), sort_size);
 
 		gtk_text_buffer_get_iter_at_offset(GTK_TEXT_BUFFER(buffer), &iter_start, 0);
 		gtk_text_buffer_get_iter_at_offset(GTK_TEXT_BUFFER(buffer), &iter_end, -1);
@@ -735,7 +735,7 @@ clicked_tracklist_header(GtkWidget * widget, gpointer data) {
 
 
 int
-add_record_dialog(char * name, char * sort, char *** strings, record_data_t ** data) {
+add_record_dialog(char * name, size_t name_size, char * sort, size_t sort_size, char *** strings, record_data_t ** data) {
 
 	GtkWidget * dialog;
 	GtkWidget * content_area;
@@ -814,14 +814,14 @@ add_record_dialog(char * name, char * sort, char *** strings, record_data_t ** d
 	sort[0] = '\0';
 
         if (aqualung_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
-                strcpy(name, gtk_entry_get_text(GTK_ENTRY(name_entry)));
+		g_strlcpy(name, gtk_entry_get_text(GTK_ENTRY(name_entry)), name_size);
 
 		if (name[0] == '\0') {
 			gtk_widget_grab_focus(name_entry);
 			goto display;
 		}
 
-                strcpy(sort, gtk_entry_get_text(GTK_ENTRY(sort_entry)));
+		g_strlcpy(sort, gtk_entry_get_text(GTK_ENTRY(sort_entry)), sort_size);
 
 		if ((n = gtk_tree_model_iter_n_children(GTK_TREE_MODEL(store), NULL)) > 0) {
 
@@ -873,7 +873,7 @@ add_record_dialog(char * name, char * sort, char *** strings, record_data_t ** d
 
 
 int
-edit_record_dialog(char * name, char * sort, record_data_t * data) {
+edit_record_dialog(char * name, size_t name_size, char * sort, size_t sort_size, record_data_t * data) {
 
 	GtkWidget * dialog;
 	GtkWidget * table;
@@ -903,14 +903,14 @@ edit_record_dialog(char * name, char * sort, record_data_t * data) {
 
         if (aqualung_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
 
-                strcpy(name, gtk_entry_get_text(GTK_ENTRY(name_entry)));
+		g_strlcpy(name, gtk_entry_get_text(GTK_ENTRY(name_entry)), name_size);
 
 		if (name[0] == '\0') {
 			gtk_widget_grab_focus(name_entry);
 			goto display;
 		}
 
-                strcpy(sort, gtk_entry_get_text(GTK_ENTRY(sort_entry)));
+		g_strlcpy(sort, gtk_entry_get_text(GTK_ENTRY(sort_entry)), sort_size);
 
 		data->year = gtk_spin_button_get_value(GTK_SPIN_BUTTON(year_spin));
 
@@ -940,7 +940,7 @@ browse_button_track_clicked(GtkButton * button, gpointer data) {
 
 
 int
-add_track_dialog(char * name, char * sort, track_data_t ** data) {
+add_track_dialog(char * name, size_t name_size, char * sort, size_t sort_size, track_data_t ** data) {
 
 	GtkWidget * dialog;
 	GtkWidget * table;
@@ -972,7 +972,7 @@ add_track_dialog(char * name, char * sort, track_data_t ** data) {
 		char file[MAXLEN];
 		float duration;
 
-		strncpy(name, gtk_entry_get_text(GTK_ENTRY(name_entry)), MAXLEN-1);
+		g_strlcpy(name, gtk_entry_get_text(GTK_ENTRY(name_entry)), name_size);
 		if (name[0] == '\0') {
 			gtk_widget_grab_focus(name_entry);
 			goto display;
@@ -989,7 +989,7 @@ add_track_dialog(char * name, char * sort, track_data_t ** data) {
 			return 0;
 		}
 
-                strcpy(sort, gtk_entry_get_text(GTK_ENTRY(sort_entry)));
+		g_strlcpy(sort, gtk_entry_get_text(GTK_ENTRY(sort_entry)), sort_size);
 
 		normalize_filename(pfile, file, CHAR_ARRAY_SIZE(file));
 		free_strdup(&(*data)->file, file);
@@ -1028,7 +1028,7 @@ edit_track_done(GtkEntry * entry, gpointer data) {
 }
 
 int
-edit_track_dialog(char * name, char * sort, track_data_t * data) {
+edit_track_dialog(char * name, size_t name_size, char * sort, size_t sort_size, track_data_t * data) {
 
 	GtkWidget * dialog;
 	GtkWidget * table;
@@ -1110,7 +1110,7 @@ edit_track_dialog(char * name, char * sort, track_data_t * data) {
 		const char * pfile = g_filename_from_utf8(gtk_entry_get_text(GTK_ENTRY(file_entry)), -1, NULL, NULL, NULL);
 		char file[MAXLEN];
 
-		strncpy(name, gtk_entry_get_text(GTK_ENTRY(name_entry)), MAXLEN-1);
+		g_strlcpy(name, gtk_entry_get_text(GTK_ENTRY(name_entry)), name_size);
 		if (name[0] == '\0') {
 			gtk_widget_grab_focus(name_entry);
 			goto display;
@@ -1122,7 +1122,7 @@ edit_track_dialog(char * name, char * sort, track_data_t * data) {
 			goto display;
 		}
 
-                strcpy(sort, gtk_entry_get_text(GTK_ENTRY(sort_entry)));
+		g_strlcpy(sort, gtk_entry_get_text(GTK_ENTRY(sort_entry)), sort_size);
 
 		normalize_filename(pfile, file, CHAR_ARRAY_SIZE(file));
 		free_strdup(&data->file, file);
@@ -1849,7 +1849,7 @@ store__add_cb(gpointer user_data) {
 
 	name[0] = '\0';
 
-	if (add_store_dialog(name, &data)) {
+	if (add_store_dialog(name, CHAR_ARRAY_SIZE(name), &data)) {
 
 		if (access(data->file, F_OK) == 0) {
 			message_dialog(_("Create empty store"),
@@ -1925,6 +1925,7 @@ store__edit_cb(gpointer user_data) {
 
 	char * pname;
 	char name[MAXLEN+1];
+	int offset;
 
 	if (gtk_tree_selection_get_selected(music_select, &model, &iter)) {
 
@@ -1940,7 +1941,8 @@ store__edit_cb(gpointer user_data) {
 		strncpy(name, pname, MAXLEN-1);
 		g_free(pname);
 
-		if (edit_store_dialog(name + ((data->dirty) ? 1 : 0), data)) {
+		offset = ((data->dirty) ? 1 : 0);
+		if (edit_store_dialog(name + offset, CHAR_ARRAY_SIZE(name) - offset, data)) {
 			gtk_tree_store_set(music_store, &iter,
 					   MS_COL_NAME, name, -1);
 
@@ -2149,7 +2151,7 @@ artist__add_cb(gpointer user_data) {
 		gtk_tree_model_get_iter(model, &parent_iter, parent_path);
 		gtk_tree_path_free(parent_path);
 
-		if (add_artist_dialog(name, sort, &data)) {
+		if (add_artist_dialog(name, CHAR_ARRAY_SIZE(name), sort, CHAR_ARRAY_SIZE(sort), &data)) {
 			gtk_tree_store_append(music_store, &iter, &parent_iter);
 			gtk_tree_store_set(music_store, &iter,
 					   MS_COL_NAME, name,
@@ -2192,7 +2194,7 @@ artist__edit_cb(gpointer user_data) {
                 g_free(pname);
                 g_free(psort);
 
-		if (edit_artist_dialog(name, sort, data)) {
+		if (edit_artist_dialog(name, CHAR_ARRAY_SIZE(name), sort, CHAR_ARRAY_SIZE(sort), data)) {
 
 			gtk_tree_store_set(music_store, &iter,
 					   MS_COL_NAME, name,
@@ -2337,7 +2339,7 @@ record__add_cb(gpointer user_data) {
 			gtk_tree_path_up(parent_path);
 		gtk_tree_model_get_iter(model, &parent_iter, parent_path);
 
-		if (add_record_dialog(name, sort, &strings, &data)) {
+		if (add_record_dialog(name, CHAR_ARRAY_SIZE(name), sort, CHAR_ARRAY_SIZE(sort), &strings, &data)) {
 
 			gtk_tree_store_append(music_store, &iter, &parent_iter);
 			gtk_tree_store_set(music_store, &iter,
@@ -2424,7 +2426,7 @@ record__edit_cb(gpointer user_data) {
                 g_free(pname);
                 g_free(psort);
 
-		if (edit_record_dialog(name, sort, data)) {
+		if (edit_record_dialog(name, CHAR_ARRAY_SIZE(name), sort, CHAR_ARRAY_SIZE(sort), data)) {
 
 			gtk_tree_store_set(music_store, &iter,
 					   MS_COL_NAME, name,
@@ -2600,7 +2602,7 @@ track__add_cb(gpointer user_data) {
 		}
 		gtk_tree_model_get_iter(model, &parent_iter, parent_path);
 
-		if (add_track_dialog(name, sort, &data)) {
+		if (add_track_dialog(name, CHAR_ARRAY_SIZE(name), sort, CHAR_ARRAY_SIZE(sort), &data)) {
 
 			gtk_tree_store_append(music_store, &iter, &parent_iter);
 			gtk_tree_store_set(music_store, &iter,
@@ -2648,7 +2650,8 @@ track__edit_cb(gpointer user_data) {
                 g_free(pname);
                 g_free(psort);
 
-                if (edit_track_dialog(name, sort, data)) {
+		if (edit_track_dialog(name, CHAR_ARRAY_SIZE(name),
+				      sort, CHAR_ARRAY_SIZE(sort), data)) {
 
                         gtk_tree_store_set(music_store, &iter,
 					   MS_COL_NAME, name,

--- a/src/store_podcast.c
+++ b/src/store_podcast.c
@@ -374,7 +374,7 @@ podcast_dialog(podcast_t ** podcast, int create) {
 				return 0;
 			}
 
-			normalize_filename(pdir, dir);
+			normalize_filename(pdir, dir, CHAR_ARRAY_SIZE(dir));
 			(*podcast)->dir = strdup(dir);
 			(*podcast)->url = strdup(url);
 			strncpy(options.podcastdir, dir, MAXLEN-1);

--- a/src/store_podcast.c
+++ b/src/store_podcast.c
@@ -1402,32 +1402,32 @@ set_status_bar_info(GtkTreeIter * tree_iter, GtkLabel * statusbar) {
 	switch (depth) {
 	case 3:
 		item_status_bar_info(model, tree_iter, &size, &length, &nnewitem);
-		sprintf(str, "%s ", name);
+		arr_snprintf(str, "%s ", name);
 		break;
 	case 2:
 		gtk_tree_model_get(model, tree_iter, MS_COL_DATA, &podcast, -1);
 		podcast_get_display_name(podcast, tmp, CHAR_ARRAY_SIZE(tmp));
 		feed_status_bar_info(model, tree_iter, &size, &length, &nnewitem, &nitem);
 		if (nnewitem > 0) {
-			sprintf(str, "%s:  %d %s, %d %s ", tmp,
-				nitem, (nitem == 1) ? _("item") : _("items"),
-				nnewitem, (nnewitem == 1) ? _("new item") : _("new items"));
+			arr_snprintf(str, "%s:  %d %s, %d %s ", tmp,
+				     nitem, (nitem == 1) ? _("item") : _("items"),
+				     nnewitem, (nnewitem == 1) ? _("new item") : _("new items"));
 		} else {
-			sprintf(str, "%s:  %d %s ", tmp,
-				nitem, (nitem == 1) ? _("item") : _("items"));
+			arr_snprintf(str, "%s:  %d %s ", tmp,
+				     nitem, (nitem == 1) ? _("item") : _("items"));
 		}
 		break;
 	case 1:
 		store_status_bar_info(model, tree_iter, &size, &length, &nnewitem, &nitem, &nfeed);
 		if (nnewitem > 0) {
-			sprintf(str, "%s:  %d %s, %d %s, %d %s ", name,
-				nfeed, (nfeed == 1) ? _("feed") : _("feeds"),
-				nitem, (nitem == 1) ? _("item") : _("items"),
-				nnewitem, (nnewitem == 1) ? _("new item") : _("new items"));
+			arr_snprintf(str, "%s:  %d %s, %d %s, %d %s ", name,
+				     nfeed, (nfeed == 1) ? _("feed") : _("feeds"),
+				     nitem, (nitem == 1) ? _("item") : _("items"),
+				     nnewitem, (nnewitem == 1) ? _("new item") : _("new items"));
 		} else {
-			sprintf(str, "%s:  %d %s, %d %s ", name,
-				nfeed, (nfeed == 1) ? _("feed") : _("feeds"),
-				nitem, (nitem == 1) ? _("item") : _("items"));
+			arr_snprintf(str, "%s:  %d %s, %d %s ", name,
+				     nfeed, (nfeed == 1) ? _("feed") : _("feeds"),
+				     nitem, (nitem == 1) ? _("item") : _("items"));
 		}
 		break;
 	}
@@ -1436,7 +1436,7 @@ set_status_bar_info(GtkTreeIter * tree_iter, GtkLabel * statusbar) {
 
 	if (length > 0.0f || nitem == 0) {
 		time2time(length, length_str, CHAR_ARRAY_SIZE(length_str));
-		sprintf(tmp, " [%s] ", length_str);
+		arr_snprintf(tmp, " [%s] ", length_str);
 	} else {
 		strcpy(tmp, " [N/A] ");
 	}
@@ -1445,11 +1445,11 @@ set_status_bar_info(GtkTreeIter * tree_iter, GtkLabel * statusbar) {
 
 	if (options.ms_statusbar_show_size) {
 		if (size > 1024 * 1024) {
-			sprintf(tmp, " (%.1f GB) ", size / (1024 * 1024));
+			arr_snprintf(tmp, " (%.1f GB) ", size / (1024 * 1024));
 		} else if (size > 1024) {
-			sprintf(tmp, " (%.1f MB) ", size / 1024);
+			arr_snprintf(tmp, " (%.1f MB) ", size / 1024);
 		} else if (size > 0 || nitem == 0) {
-			sprintf(tmp, " (%.1f KB) ", size);
+			arr_snprintf(tmp, " (%.1f KB) ", size);
 		} else {
 			strcpy(tmp, " (N/A) ");
 		}
@@ -1650,9 +1650,9 @@ store_podcast_load_icons(void) {
 
 	char path[MAXLEN];
 
-	sprintf(path, "%s/%s", AQUALUNG_DATADIR, "ms-podcast.png");
+	arr_snprintf(path, "%s/%s", AQUALUNG_DATADIR, "ms-podcast.png");
 	icon_podcasts = gdk_pixbuf_new_from_file (path, NULL);
-	sprintf(path, "%s/%s", AQUALUNG_DATADIR, "ms-feed.png");
+	arr_snprintf(path, "%s/%s", AQUALUNG_DATADIR, "ms-feed.png");
 	icon_feed = gdk_pixbuf_new_from_file (path, NULL);
 }
 

--- a/src/store_podcast.c
+++ b/src/store_podcast.c
@@ -1443,7 +1443,7 @@ set_status_bar_info(GtkTreeIter * tree_iter, GtkLabel * statusbar) {
 		strcpy(tmp, " [N/A] ");
 	}
 
-	strcat(str, tmp);
+	arr_strlcat(str, tmp);
 
 	if (options.ms_statusbar_show_size) {
 		if (size > 1024 * 1024) {
@@ -1455,7 +1455,7 @@ set_status_bar_info(GtkTreeIter * tree_iter, GtkLabel * statusbar) {
 		} else {
 			strcpy(tmp, " (N/A) ");
 		}
-		strcat(str, tmp);
+		arr_strlcat(str, tmp);
 	}
 
 	gtk_label_set_text(statusbar, str);

--- a/src/store_podcast.c
+++ b/src/store_podcast.c
@@ -2031,7 +2031,7 @@ parse_podcast_item(xmlDocPtr doc, xmlNodePtr cur, GtkTreeIter * pod_iter, podcas
 		xml_load_str_dup(doc, cur, "title", &item->title);
 		xml_load_str_dup(doc, cur, "desc", &item->desc);
 		xml_load_str_dup(doc, cur, "url", &item->url);
-		xml_load_str(doc, cur, "sort", sort);
+		xml_load_str(doc, cur, "sort", sort, CHAR_ARRAY_SIZE(sort));
 
 		xml_load_int(doc, cur, "new", &item->new);
 		xml_load_float(doc, cur, "duration", &item->duration);

--- a/src/store_podcast.c
+++ b/src/store_podcast.c
@@ -443,7 +443,7 @@ podcast_track_addlist_iter(GtkTreeIter iter_track, playlist_t * pl,
 		gtk_tree_model_get(GTK_TREE_MODEL(pl->store), piter, PL_COL_DATA, &pdata, -1);
 		if (pdata->artist && pdata->album && podcast->author && podcast->title &&
 		    !strcmp(pdata->artist, podcast->author) && !strcmp(pdata->album, podcast->title)) {
-			strcpy(list_str, item->title);
+			arr_strlcpy(list_str, item->title);
 		} else {
 			make_title_string(list_str, CHAR_ARRAY_SIZE(list_str), options.title_format,
 					  podcast->author, podcast->title, item->title);
@@ -1440,7 +1440,7 @@ set_status_bar_info(GtkTreeIter * tree_iter, GtkLabel * statusbar) {
 		time2time(length, length_str, CHAR_ARRAY_SIZE(length_str));
 		arr_snprintf(tmp, " [%s] ", length_str);
 	} else {
-		strcpy(tmp, " [N/A] ");
+		arr_strlcpy(tmp, " [N/A] ");
 	}
 
 	arr_strlcat(str, tmp);
@@ -1453,7 +1453,7 @@ set_status_bar_info(GtkTreeIter * tree_iter, GtkLabel * statusbar) {
 		} else if (size > 0 || nitem == 0) {
 			arr_snprintf(tmp, " (%.1f KB) ", size);
 		} else {
-			strcpy(tmp, " (N/A) ");
+			arr_strlcpy(tmp, " (N/A) ");
 		}
 		arr_strlcat(str, tmp);
 	}

--- a/src/store_podcast.c
+++ b/src/store_podcast.c
@@ -358,7 +358,7 @@ podcast_dialog(podcast_t ** podcast, int create) {
 			char dir[MAXLEN];
 			char url[MAXLEN];
 
-			strncpy(url, gtk_entry_get_text(GTK_ENTRY(url_entry)), MAXLEN-1);
+			arr_strlcpy(url, gtk_entry_get_text(GTK_ENTRY(url_entry)));
 			if (url[0] == '\0') {
 				gtk_widget_grab_focus(url_entry);
 				goto display;
@@ -377,7 +377,7 @@ podcast_dialog(podcast_t ** podcast, int create) {
 			normalize_filename(pdir, dir, CHAR_ARRAY_SIZE(dir));
 			(*podcast)->dir = strdup(dir);
 			(*podcast)->url = strdup(url);
-			strncpy(options.podcastdir, dir, MAXLEN-1);
+			arr_strlcpy(options.podcastdir, dir);
 		}
 
 		if (options.podcasts_autocheck || create) {
@@ -1032,8 +1032,8 @@ podcast_track_export(GtkTreeIter * iter_track, export_t * export, char * author,
 		gtk_tree_model_get(GTK_TREE_MODEL(music_store), &iter_podcast, MS_COL_DATA, &podcast, -1);
 	}
 
-	strncpy(artist, (author == NULL) ? podcast->author : author, MAXLEN-1);
-	strncpy(album, (feed == NULL) ? podcast->title : feed, MAXLEN-1);
+	arr_strlcpy(artist, (author == NULL) ? podcast->author : author);
+	arr_strlcpy(album, (feed == NULL) ? podcast->title : feed);
 
 	export_append_item(export, item->file, artist, album, title, 0, 0);
 

--- a/src/store_podcast.c
+++ b/src/store_podcast.c
@@ -451,7 +451,7 @@ podcast_track_addlist_iter(GtkTreeIter iter_track, playlist_t * pl,
 		make_title_string(list_str, options.title_format, podcast->author, podcast->title, item->title);
 	}
 
-	time2time(item->duration, duration_str);
+	time2time(item->duration, duration_str, CHAR_ARRAY_SIZE(duration_str));
 
 	if ((pldata = playlist_data_new()) == NULL) {
 		return 0;
@@ -558,7 +558,7 @@ podcast_feed_addlist_iter(GtkTreeIter iter_record, playlist_t * pl, GtkTreeIter 
 	if (album_mode) {
 		char duration_str[MAXLEN];
 		pldata->duration = record_duration;
-		time2time(record_duration, duration_str);
+		time2time(record_duration, duration_str, CHAR_ARRAY_SIZE(duration_str));
 		gtk_tree_store_set(pl->store, &list_iter, PL_COL_DURA, duration_str, -1);
 	}
 }
@@ -1435,7 +1435,7 @@ set_status_bar_info(GtkTreeIter * tree_iter, GtkLabel * statusbar) {
 	g_free(name);
 
 	if (length > 0.0f || nitem == 0) {
-		time2time(length, length_str);
+		time2time(length, length_str, CHAR_ARRAY_SIZE(length_str));
 		sprintf(tmp, " [%s] ", length_str);
 	} else {
 		strcpy(tmp, " [N/A] ");

--- a/src/store_podcast.c
+++ b/src/store_podcast.c
@@ -232,7 +232,7 @@ podcast_browse_button_clicked(GtkButton * button, gpointer data) {
 				GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
 				FILE_CHOOSER_FILTER_NONE,
 				(GtkWidget *)data,
-				options.podcastdir);
+				options.podcastdir, CHAR_ARRAY_SIZE(options.podcastdir));
 }
 
 void

--- a/src/store_podcast.c
+++ b/src/store_podcast.c
@@ -943,7 +943,7 @@ podcast_store__reorder_cb(gpointer data) {
 		podcast_t * podcast;
 
 		gtk_tree_model_get(GTK_TREE_MODEL(music_store), &pod_iter, MS_COL_DATA, &podcast, -1);
-		podcast_get_display_name(podcast, title);
+		podcast_get_display_name(podcast, title, CHAR_ARRAY_SIZE(title));
 		gtk_list_store_append(store, &list_iter);
 		gtk_list_store_set(store, &list_iter, 0, title, 1, gtk_tree_iter_copy(&pod_iter), -1);
 	}
@@ -1166,7 +1166,7 @@ podcast_iter_set_display_name(podcast_t * podcast, GtkTreeIter * pod_iter) {
 
 	char name_str[MAXLEN];
 
-	podcast_get_display_name(podcast, name_str);
+	podcast_get_display_name(podcast, name_str, CHAR_ARRAY_SIZE(name_str));
 	gtk_tree_store_set(music_store, pod_iter, MS_COL_NAME, name_str, -1);
 }
 
@@ -1406,7 +1406,7 @@ set_status_bar_info(GtkTreeIter * tree_iter, GtkLabel * statusbar) {
 		break;
 	case 2:
 		gtk_tree_model_get(model, tree_iter, MS_COL_DATA, &podcast, -1);
-		podcast_get_display_name(podcast, tmp);
+		podcast_get_display_name(podcast, tmp, CHAR_ARRAY_SIZE(tmp));
 		feed_status_bar_info(model, tree_iter, &size, &length, &nnewitem, &nitem);
 		if (nnewitem > 0) {
 			sprintf(str, "%s:  %d %s, %d %s ", tmp,
@@ -1512,7 +1512,7 @@ add_path_to_playlist(GtkTreePath * path, GtkTreeIter * piter, int new_tab) {
 			podcast_t * podcast;
 
 			gtk_tree_model_get(GTK_TREE_MODEL(music_store), &iter, MS_COL_DATA, &podcast, -1);
-			podcast_get_display_name(podcast, name);
+			podcast_get_display_name(podcast, name, CHAR_ARRAY_SIZE(name));
 			playlist_tab_new_if_nonempty(name);
 		} else {
 			char * name;

--- a/src/store_podcast.c
+++ b/src/store_podcast.c
@@ -445,10 +445,12 @@ podcast_track_addlist_iter(GtkTreeIter iter_track, playlist_t * pl,
 		    !strcmp(pdata->artist, podcast->author) && !strcmp(pdata->album, podcast->title)) {
 			strcpy(list_str, item->title);
 		} else {
-			make_title_string(list_str, options.title_format, podcast->author, podcast->title, item->title);
+			make_title_string(list_str, CHAR_ARRAY_SIZE(list_str), options.title_format,
+					  podcast->author, podcast->title, item->title);
 		}
 	} else {
-		make_title_string(list_str, options.title_format, podcast->author, podcast->title, item->title);
+		make_title_string(list_str, CHAR_ARRAY_SIZE(list_str), options.title_format,
+				  podcast->author, podcast->title, item->title);
 	}
 
 	time2time(item->duration, duration_str, CHAR_ARRAY_SIZE(duration_str));
@@ -2148,7 +2150,8 @@ store_model_func(GtkTreeModel * model, GtkTreeIter iter, char**name, char**file)
 	gtk_tree_model_get(model, &iter, MS_COL_DATA, &item, -1);
 	gtk_tree_model_iter_parent(model, &pod_iter, &iter);
 	gtk_tree_model_get(model, &pod_iter, MS_COL_DATA, &podcast, -1);
-	make_title_string(buf, options.title_format, podcast->author, podcast->title, item->title);
+	make_title_string(buf, CHAR_ARRAY_SIZE(buf), options.title_format,
+			  podcast->author, podcast->title, item->title);
 
 	*name = strndup(buf, MAXLEN-1);
 	*file = strdup(item->file);

--- a/src/store_podcast.c
+++ b/src/store_podcast.c
@@ -528,9 +528,9 @@ podcast_feed_addlist_iter(GtkTreeIter iter_record, playlist_t * pl, GtkTreeIter 
 
 		gtk_tree_model_get(GTK_TREE_MODEL(music_store), &iter_record, MS_COL_DATA, &podcast, -1);
 
-		snprintf(list_str, MAXLEN-1, "%s: %s",
-			 podcast->author ? podcast->author : _("Podcasts"),
-			 podcast->title);
+		arr_snprintf(list_str, "%s: %s",
+			     podcast->author ? podcast->author : _("Podcasts"),
+			     podcast->title);
 
 		pldata->artist = strndup(podcast->author ? podcast->author : _("Podcasts"), MAXLEN-1);
 		pldata->album = strdup(podcast->title);
@@ -961,7 +961,7 @@ podcast_store__reorder_cb(gpointer data) {
 		if (res == GTK_RESPONSE_ACCEPT) {
 			char sort[16];
 
-			snprintf(sort, 15, "%03d", i);
+			arr_snprintf(sort, "%03d", i);
 			gtk_tree_store_set(music_store, iter, MS_COL_SORT, sort, -1);
 		}
 
@@ -1200,7 +1200,7 @@ store_podcast_update_podcast_download_cb(gpointer data) {
 		return FALSE;
 	}
 
-	snprintf(name_str, MAXLEN-1, _("Downloading %d/%d (%d%%) ..."), pd->ncurrent, pd->ndownloads, pd->percent);
+	arr_snprintf(name_str, _("Downloading %d/%d (%d%%) ..."), pd->ncurrent, pd->ndownloads, pd->percent);
 	gtk_tree_store_set(music_store, &pod_iter, MS_COL_NAME, name_str, -1);
 
 	return FALSE;
@@ -1219,7 +1219,7 @@ store_podcast_add_item_cb(gpointer data) {
 		return FALSE;
 	}
 
-	snprintf(sort, 15, "%014lld", 10000000000LL - pt->item->date);
+	arr_snprintf(sort, "%014lld", 10000000000LL - pt->item->date);
 
 	gtk_tree_store_append(music_store, &iter, &pod_iter);
 	gtk_tree_store_set(music_store, &iter,
@@ -1995,7 +1995,7 @@ store_podcast_save(void) {
 		save_podcast(doc, root, &pod_iter);
 	}
 
-	snprintf(file, MAXLEN-1, "%s/podcast.xml", options.confdir);
+	arr_snprintf(file, "%s/podcast.xml", options.confdir);
 	xmlSaveFormatFile(file, doc, 1);
 	xmlFreeDoc(doc);
 
@@ -2098,7 +2098,7 @@ store_podcast_load(void) {
 	xmlNodePtr cur;
 	char file[MAXLEN];
 	
-	snprintf(file, MAXLEN-1, "%s/podcast.xml", options.confdir);
+	arr_snprintf(file, "%s/podcast.xml", options.confdir);
 	if (!g_file_test(file, G_FILE_TEST_EXISTS)) {
 		return;
 	}

--- a/src/transceiver.c
+++ b/src/transceiver.c
@@ -133,7 +133,7 @@ send_message(const char * filename, char * message, int len) {
         struct sockaddr_un name;
         int nbytes;
 
-	sprintf(tempsockname, "/tmp/aqualung_%s.tmp", g_get_user_name());
+	arr_snprintf(tempsockname, "/tmp/aqualung_%s.tmp", g_get_user_name());
 	sock = create_socket(tempsockname);
         name.sun_family = AF_LOCAL;
         strcpy(name.sun_path, filename);
@@ -156,7 +156,7 @@ send_message_to_session_report_error(int session_id, char * message, int len, in
 	char name[MAXLEN];
 	int nbytes = 0;
 
-	sprintf(name, "/tmp/aqualung_%s.%d", g_get_user_name(), session_id);
+	arr_snprintf(name, "/tmp/aqualung_%s.%d", g_get_user_name(), session_id);
 	if((nbytes = send_message(name, message, len)) < 0 && report_error) {
 		perror("send_message(): sendto");
 	}
@@ -179,7 +179,7 @@ setup_app_socket(void) {
 
 	for (i=0; sock == -1; i++) {
 		if (send_message_to_session_report_error(i, &rcmd, 1, 0) < 0) {
-			sprintf(name, "/tmp/aqualung_%s.%d", g_get_user_name(), i);
+			arr_snprintf(name, "/tmp/aqualung_%s.%d", g_get_user_name(), i);
 			unlink(name);
 			sock = create_socket(name);
 		}

--- a/src/transceiver.c
+++ b/src/transceiver.c
@@ -66,7 +66,7 @@ create_socket(const char * filename) {
 
 
 char
-receive_message(int fd, char * cmdarg) {
+receive_message(int fd, char * cmdarg, size_t cmdarg_size) {
 	
 	fd_set set;
 	struct timeval tv;
@@ -105,15 +105,15 @@ receive_message(int fd, char * cmdarg) {
 	case RCMD_VOLADJ:
 	case RCMD_ADD_FILE:
 	case RCMD_CUSTOM:
-		strncpy(cmdarg, buffer + 1, MAXLEN-2);
+		g_strlcpy(cmdarg, buffer + 1, cmdarg_size);
 		return rcmd;
 
 	case RCMD_ADD_COMMIT:
+		g_assert(cmdarg_size >= 4);
 		for (i = 1; i <= 3; i++) {
 			cmdarg[i-1] = buffer[i];
 		}
-		cmdarg[3] = '\0';
-		strncpy(cmdarg + 3, buffer + 4, MAXLEN-5);
+		g_strlcpy(cmdarg + 3, buffer + 4, cmdarg_size - 3);
 		return rcmd;
 
 	default:
@@ -187,7 +187,7 @@ setup_app_socket(void) {
 	
 	aqualung_socket_fd = sock;
 	aqualung_session_id = --i;
-	strncpy(aqualung_socket_filename, name, 255);
+	arr_strlcpy(aqualung_socket_filename, name);
 }
 
 

--- a/src/transceiver.c
+++ b/src/transceiver.c
@@ -54,7 +54,7 @@ create_socket(const char * filename) {
 	}
 	
 	name.sun_family = AF_LOCAL;
-	strncpy(name.sun_path, filename, sizeof(name.sun_path));
+	arr_strlcpy(name.sun_path, filename);
 	size = SUN_LEN(&name);
 	if (bind(sock, (struct sockaddr *)&name, size) < 0) {
 		perror("create_socket(): bind");
@@ -136,7 +136,7 @@ send_message(const char * filename, char * message, int len) {
 	arr_snprintf(tempsockname, "/tmp/aqualung_%s.tmp", g_get_user_name());
 	sock = create_socket(tempsockname);
         name.sun_family = AF_LOCAL;
-        strcpy(name.sun_path, filename);
+        arr_strlcpy(name.sun_path, filename);
 
 	do {
 		nbytes = sendto(sock, message, len+1, 0, (struct sockaddr *)&name, sizeof(name));

--- a/src/transceiver.h
+++ b/src/transceiver.h
@@ -36,7 +36,7 @@
 #define RCMD_CUSTOM     11
 
 int create_socket(const char * filename);
-char receive_message(int fd, char * cmd_arg);
+char receive_message(int fd, char * cmdarg, size_t cmdarg_size);
 void setup_app_socket(void);
 void close_app_socket(void);
 int send_message(const char * filename, char * message, int len);

--- a/src/utils.c
+++ b/src/utils.c
@@ -463,7 +463,7 @@ map_new(char * str) {
 		return NULL;
 	}
 
-	strncpy(map->str, str, MAXLEN-1);
+	arr_strlcpy(map->str, str);
 	map->count = 1;
 	map->next = NULL;
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -254,10 +254,10 @@ make_string_va(char * buf, size_t buf_size, char * format, ...) {
 }
 
 void
-make_title_string(char * dest, char * templ,
+make_title_string(char * dest, size_t dest_size, char * templ,
 		  char * artist, char * record, char * track) {
 
-	make_string_va(dest, MAXLEN, templ, 'a', artist, 'r', record, 't', track, 0);
+	make_string_va(dest, dest_size, templ, 'a', artist, 'r', record, 't', track, 0);
 }
 
 void

--- a/src/utils.c
+++ b/src/utils.c
@@ -135,7 +135,7 @@ contains(int * cbuf, int num, char c) {
     -4: error: unknown conversion type character after '?'
  */
 int
-make_string_va(char * buf, char * format, ...) {
+make_string_va(char * buf, size_t buf_size, char * format, ...) {
 
 	va_list args;
 	char ** strbuf = NULL;
@@ -177,7 +177,7 @@ make_string_va(char * buf, char * format, ...) {
 			} else {
 				if (strbuf[n]) {
 					buf[j] = '\0';
-					strcat(buf, strbuf[n]);
+					g_strlcat(buf, strbuf[n], buf_size);
 					j = strlen(buf);
 				}
 				i += 2;
@@ -212,14 +212,16 @@ make_string_va(char * buf, char * format, ...) {
 					} else {
 						if (disj && strbuf[n]) {
 							buf[j] = '\0';
-							strcat(buf, strbuf[n]);
+							g_strlcat(buf, strbuf[n], buf_size);
 							j = strlen(buf);
 						}
 						i += 2;
 					}
 				} else {
 					if (disj) {
-						buf[j++] = format[i];
+						if (j + 1 < buf_size) {
+							buf[j++] = format[i];
+						}
 					}
 					++i;
 				}
@@ -230,7 +232,9 @@ make_string_va(char * buf, char * format, ...) {
 			++i;
 			break;
 		default:
-			buf[j++] = format[i++];
+			if (j + 1 < buf_size) {
+				buf[j++] = format[i++];
+			}
 			break;
 		}
 	}
@@ -253,7 +257,7 @@ void
 make_title_string(char * dest, char * templ,
 		  char * artist, char * record, char * track) {
 
-	make_string_va(dest, templ, 'a', artist, 'r', record, 't', track, 0);
+	make_string_va(dest, MAXLEN, templ, 'a', artist, 'r', record, 't', track, 0);
 }
 
 void

--- a/src/utils.c
+++ b/src/utils.c
@@ -343,24 +343,23 @@ time2time_na(float seconds, char * str) {
 }
 
 
-/* out should be defined as char[MAXLEN] */
 void
-normalize_filename(const char * in, char * out) {
+normalize_filename(const char * in, char * out, size_t out_size) {
 
 	if (httpc_is_url(in)) {
-		strncpy(out, in, MAXLEN-1);
+		g_strlcpy(out, in, out_size);
 		return;
 	}
 
 	switch (in[0]) {
 	case '/':
-		strncpy(out, in, MAXLEN-1);
+		g_strlcpy(out, in, out_size);
 		break;
 	case '~':
-		snprintf(out, MAXLEN-1, "%s%s", options.home, in + 1);
+		snprintf(out, out_size, "%s%s", options.home, in + 1);
 		break;
 	default:
-		snprintf(out, MAXLEN-1, "%s/%s", options.cwd, in);
+		snprintf(out, out_size, "%s/%s", options.cwd, in);
 		break;
 	}
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -277,7 +277,7 @@ make_string_strerror(int ret, char * buf) {
 
 /* returns (hh:mm:ss) or (mm:ss) format time string from sample position */
 void
-sample2time(unsigned long SR, unsigned long long sample, char * str, int sign) {
+sample2time(unsigned long SR, unsigned long long sample, char * str, size_t str_size, int sign) {
 
 	int h;
 	char m, s;
@@ -290,16 +290,16 @@ sample2time(unsigned long SR, unsigned long long sample, char * str, int sign) {
 	s = (sample / SR) - h * 3600 - m * 60;
 
 	if (h > 0) {
-		sprintf(str, (sign)?("-%d:%02d:%02d"):("%d:%02d:%02d"), h, m, s);
+		snprintf(str, str_size, (sign)?("-%d:%02d:%02d"):("%d:%02d:%02d"), h, m, s);
 	} else {
-		sprintf(str, (sign)?("-%02d:%02d"):("%02d:%02d"), m, s);
+		snprintf(str, str_size, (sign)?("-%02d:%02d"):("%02d:%02d"), m, s);
 	}
 }
 
 
 /* converts a length measured in seconds to the appropriate string */
 void
-time2time(float seconds, char * str) {
+time2time(float seconds, char * str, size_t str_size) {
 
 	int d, h;
 	char m, s;
@@ -312,33 +312,33 @@ time2time(float seconds, char * str) {
 
         if (d > 0) {
                 if (d == 1 && h > 9) {
-                        sprintf(str, "%d %s, %2d:%02d:%02d", d, _("day"), h, m, s);
+                        snprintf(str, str_size, "%d %s, %2d:%02d:%02d", d, _("day"), h, m, s);
                 } else if (d == 1 && h < 9) {
-                        sprintf(str, "%d %s, %1d:%02d:%02d", d, _("day"), h, m, s);
+                        snprintf(str, str_size, "%d %s, %1d:%02d:%02d", d, _("day"), h, m, s);
                 } else if (d != 1 && h > 9) {
-                        sprintf(str, "%d %s, %2d:%02d:%02d", d, _("days"), h, m, s);
+                        snprintf(str, str_size, "%d %s, %2d:%02d:%02d", d, _("days"), h, m, s);
                 } else {
-                        sprintf(str, "%d %s, %1d:%02d:%02d", d, _("days"), h, m, s);
+                        snprintf(str, str_size, "%d %s, %1d:%02d:%02d", d, _("days"), h, m, s);
                 }
         } else if (h > 0) {
 		if (h > 9) {
-			sprintf(str, "%02d:%02d:%02d", h, m, s);
+			snprintf(str, str_size, "%02d:%02d:%02d", h, m, s);
 		} else {
-			sprintf(str, "%1d:%02d:%02d", h, m, s);
+			snprintf(str, str_size, "%1d:%02d:%02d", h, m, s);
 		}
 	} else {
-		sprintf(str, "%02d:%02d", m, s);
+		snprintf(str, str_size, "%02d:%02d", m, s);
 	}
 }
 
 
 void
-time2time_na(float seconds, char * str) {
+time2time_na(float seconds, char * str, size_t str_size) {
 
 	if (seconds == 0.0) {
-		strcpy(str, "N/A");
+		g_strlcpy(str, "N/A", str_size);
 	} else {
-		time2time(seconds, str);
+		time2time(seconds, str, str_size);
 	}
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -257,20 +257,20 @@ make_title_string(char * dest, char * templ,
 }
 
 void
-make_string_strerror(int ret, char * buf) {
+make_string_strerror(int ret, char * buf, size_t buf_size) {
 
 	switch (ret) {
 	case -1:
-		strncpy(buf, _("Unexpected end of string after '?'."), MAXLEN-1);
+		g_strlcpy(buf, _("Unexpected end of string after '?'."), buf_size);
 		break;
 	case -2:
-		strncpy(buf, _("Expected '}' after '{', but end of string found."), MAXLEN-1);
+		g_strlcpy(buf, _("Expected '}' after '{', but end of string found."), buf_size);
 		break;
 	case -3:
-		strncpy(buf, _("Unknown conversion type character found after '%%'."), MAXLEN-1);
+		g_strlcpy(buf, _("Unknown conversion type character found after '%%'."), buf_size);
 		break;
 	case -4:
-		strncpy(buf, _("Unknown conversion type character found after '?'."), MAXLEN-1);
+		g_strlcpy(buf, _("Unknown conversion type character found after '?'."), buf_size);
 		break;
 	}
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -40,9 +40,9 @@ void make_title_string(char * dest, char * templ,
 		       char * artist, char * record, char * track);
 void make_string_strerror(int ret, char * buf);
 
-void sample2time(unsigned long SR, unsigned long long sample, char * str, int sign);
-void time2time(float samples, char * str);
-void time2time_na(float seconds, char * str);
+void sample2time(unsigned long SR, unsigned long long sample, char * str, size_t str_size, int sign);
+void time2time(float samples, char * str, size_t str_size);
+void time2time_na(float seconds, char * str, size_t str_size);
 
 void normalize_filename(const char * in, char * out, size_t out_size);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -38,7 +38,7 @@ void escape_percents(char * in, char * out);
 int make_string_va(char * buf, char * format, ...);
 void make_title_string(char * dest, char * templ,
 		       char * artist, char * record, char * track);
-void make_string_strerror(int ret, char * buf);
+void make_string_strerror(int ret, char * buf, size_t buf_size);
 
 void sample2time(unsigned long SR, unsigned long long sample, char * str, size_t str_size, int sign);
 void time2time(float samples, char * str, size_t str_size);

--- a/src/utils.h
+++ b/src/utils.h
@@ -35,7 +35,7 @@ float convf(char * s);
 int cut_trailing_whitespace(char * str);
 void escape_percents(char * in, char * out);
 
-int make_string_va(char * buf, char * format, ...);
+int make_string_va(char * buf, size_t buf_size, char * format, ...);
 void make_title_string(char * dest, char * templ,
 		       char * artist, char * record, char * track);
 void make_string_strerror(int ret, char * buf, size_t buf_size);

--- a/src/utils.h
+++ b/src/utils.h
@@ -36,7 +36,7 @@ int cut_trailing_whitespace(char * str);
 void escape_percents(char * in, char * out);
 
 int make_string_va(char * buf, size_t buf_size, char * format, ...);
-void make_title_string(char * dest, char * templ,
+void make_title_string(char * dest, size_t dest_size, char * templ,
 		       char * artist, char * record, char * track);
 void make_string_strerror(int ret, char * buf, size_t buf_size);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -44,7 +44,7 @@ void sample2time(unsigned long SR, unsigned long long sample, char * str, int si
 void time2time(float samples, char * str);
 void time2time_na(float seconds, char * str);
 
-void normalize_filename(const char * in, char * out);
+void normalize_filename(const char * in, char * out, size_t out_size);
 
 void free_strdup(char ** s, const char * str);
 int is_valid_year(int y);

--- a/src/utils_gui.c
+++ b/src/utils_gui.c
@@ -602,7 +602,7 @@ file_chooser_with_entry(char * title, GtkWidget * parent, GtkFileChooserAction a
 			return;
 		}
 
-		normalize_filename(filename, path);
+		normalize_filename(filename, path, CHAR_ARRAY_SIZE(path));
 		g_free(filename);
 	} else {
 		strncpy(path, destpath, MAXLEN-1);

--- a/src/utils_gui.c
+++ b/src/utils_gui.c
@@ -529,7 +529,7 @@ assign_fc_filters(GtkFileChooser * fc, int filter) {
 
 GSList *
 file_chooser(char * title, GtkWidget * parent, GtkFileChooserAction action, int filter,
-	     gint multiple, char * destpath) {
+	     gint multiple, char * destpath, size_t destpath_size) {
 
         GtkWidget * dialog;
 	GSList * files = NULL;
@@ -561,9 +561,9 @@ file_chooser(char * title, GtkWidget * parent, GtkFileChooserAction action, int 
 
         if (aqualung_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
 
-		strncpy(destpath,
-			gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog)),
-			MAXLEN-1);
+		g_strlcpy(destpath,
+			  gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog)),
+			  destpath_size);
 
 		files = gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(dialog));
         }
@@ -575,7 +575,7 @@ file_chooser(char * title, GtkWidget * parent, GtkFileChooserAction action, int 
 
 void
 file_chooser_with_entry(char * title, GtkWidget * parent, GtkFileChooserAction action, int filter,
-			GtkWidget * entry, char * destpath) {
+			GtkWidget * entry, char * destpath, size_t destpath_size) {
 
         GtkWidget * dialog;
 	const gchar * selected_filename = gtk_entry_get_text(GTK_ENTRY(entry));
@@ -605,7 +605,7 @@ file_chooser_with_entry(char * title, GtkWidget * parent, GtkFileChooserAction a
 		normalize_filename(filename, path, CHAR_ARRAY_SIZE(path));
 		g_free(filename);
 	} else {
-		strncpy(path, destpath, MAXLEN-1);
+		arr_strlcpy(path, destpath);
 	}
 
 	gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(dialog), path);
@@ -633,7 +633,7 @@ file_chooser_with_entry(char * title, GtkWidget * parent, GtkFileChooserAction a
 
 		gtk_entry_set_text(GTK_ENTRY(entry), utf8);
 
-                strncpy(destpath, selected_filename, MAXLEN-1);
+		g_strlcpy(destpath, selected_filename, destpath_size);
 		g_free(utf8);
         }
 

--- a/src/utils_gui.c
+++ b/src/utils_gui.c
@@ -809,9 +809,9 @@ set_option_from_spin(GtkWidget * widget, int * opt) {
 }
 
 void
-set_option_from_entry(GtkWidget * widget, char * opt, int n) {
+set_option_from_entry(GtkWidget * widget, char * opt, size_t opt_size) {
 
-	strncpy(opt, gtk_entry_get_text(GTK_ENTRY(widget)), n-1);
+	g_strlcpy(opt, gtk_entry_get_text(GTK_ENTRY(widget)), opt_size);
 }
 
 void

--- a/src/utils_gui.h
+++ b/src/utils_gui.h
@@ -92,7 +92,7 @@ void insert_label_spin_with_limits(GtkWidget * table, char * ltext, GtkWidget **
 void set_option_from_toggle(GtkWidget * widget, int * opt);
 void set_option_from_combo(GtkWidget * widget, int * opt);
 void set_option_from_spin(GtkWidget * widget, int * opt);
-void set_option_from_entry(GtkWidget * widget, char * opt, int n);
+void set_option_from_entry(GtkWidget * widget, char * opt, size_t opt_size);
 void set_option_bit_from_toggle(GtkWidget * toggle, int * opt, int bit);
 
 gboolean tree_model_leaf_iter(GtkTreeModel * model, GtkTreeIter * iter, gboolean last, GtkTreeIter * out);

--- a/src/utils_gui.h
+++ b/src/utils_gui.h
@@ -63,9 +63,9 @@ void aqualung_widget_set_tooltip_text(GtkWidget * widget, const gchar * text);
 GtkWidget* gui_stock_label_button(gchar *label, const gchar *stock);
 
 GSList * file_chooser(char * title, GtkWidget * parent,
-		      GtkFileChooserAction action, int filter, gint multiple, char * destpath);
+		      GtkFileChooserAction action, int filter, gint multiple, char * destpath, size_t destpath_size);
 void file_chooser_with_entry(char * title, GtkWidget * parent,
-			     GtkFileChooserAction action, int filter, GtkWidget * entry, char * destpath);
+			     GtkFileChooserAction action, int filter, GtkWidget * entry, char * destpath, size_t destpath_size);
 
 int message_dialog(char * title, GtkWidget * parent, GtkMessageType type,
 		   GtkButtonsType buttons, GtkWidget * extra, char * text, ...);

--- a/src/utils_xml.c
+++ b/src/utils_xml.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <libxml/globals.h>
 #include <libxml/tree.h>
+#include <glib.h>
 
 #include "common.h"
 #include "utils_xml.h"
@@ -72,12 +73,12 @@ xml_save_int_array(xmlNodePtr node, char * varname, int * var, int idx) {
 }
 
 void
-xml_load_str(xmlDocPtr doc, xmlNodePtr node, char * varname, char * var) {
+xml_load_str(xmlDocPtr doc, xmlNodePtr node, char * varname, char * var, size_t var_size) {
 
 	if (!xmlStrcmp(node->name, (const xmlChar *)varname)) {
 		xmlChar * key = xmlNodeListGetString(doc, node->xmlChildrenNode, 1);
 		if (key != NULL) {
-			strncpy(var, (char *)key, MAXLEN-1);
+			g_strlcpy(var, (char *)key, var_size);
 			xmlFree(key);
 		}
 	}

--- a/src/utils_xml.c
+++ b/src/utils_xml.c
@@ -40,7 +40,7 @@ xml_save_int(xmlNodePtr node, char * varname, int var) {
 
 	char str[32];
 
-        snprintf(str, 31, "%d", var);
+        arr_snprintf(str, "%d", var);
         xmlNewTextChild(node, NULL, (const xmlChar *)varname, (xmlChar *)str);
 }
 
@@ -49,7 +49,7 @@ xml_save_uint(xmlNodePtr node, char * varname, unsigned var) {
 
 	char str[32];
 
-        snprintf(str, 31, "%u", var);
+        arr_snprintf(str, "%u", var);
         xmlNewTextChild(node, NULL, (const xmlChar *)varname, (xmlChar *)str);
 }
 
@@ -58,7 +58,7 @@ xml_save_float(xmlNodePtr node, char * varname, float var) {
 
 	char str[32];
 
-        snprintf(str, 31, "%.1f", var);
+        arr_snprintf(str, "%.1f", var);
         xmlNewTextChild(node, NULL, (const xmlChar *)varname, (xmlChar *)str);
 }
 
@@ -67,7 +67,7 @@ xml_save_int_array(xmlNodePtr node, char * varname, int * var, int idx) {
 
 	char name[MAXLEN];
 
-	snprintf(name, MAXLEN-1, "%s_%d", varname, idx);
+	arr_snprintf(name, "%s_%d", varname, idx);
 	xml_save_int(node, name, var[idx]);
 }
 
@@ -136,7 +136,7 @@ xml_load_int_array(xmlDocPtr doc, xmlNodePtr node, char * varname, int * var, in
 
 	char name[MAXLEN];
 
-	snprintf(name, MAXLEN-1, "%s_%d", varname, idx);
+	arr_snprintf(name, "%s_%d", varname, idx);
 	xml_load_int(doc, node, name, var + idx);
 }
 

--- a/src/utils_xml.h
+++ b/src/utils_xml.h
@@ -30,7 +30,7 @@ void xml_save_uint(xmlNodePtr node, char * varname, unsigned var);
 void xml_save_float(xmlNodePtr node, char * varname, float var);
 void xml_save_int_array(xmlNodePtr node, char * varname, int * var, int idx);
 
-void xml_load_str(xmlDocPtr doc, xmlNodePtr node, char * varname, char * var);
+void xml_load_str(xmlDocPtr doc, xmlNodePtr node, char * varname, char * var, size_t var_size);
 void xml_load_str_dup(xmlDocPtr doc, xmlNodePtr node, char * varname, char ** var);
 void xml_load_int(xmlDocPtr doc, xmlNodePtr node, char * varname, int * var);
 void xml_load_uint(xmlDocPtr doc, xmlNodePtr node, char * varname, unsigned * var);

--- a/src/volume.c
+++ b/src/volume.c
@@ -249,7 +249,7 @@ vol_update_progress(gpointer data) {
 		}
 
 		gtk_progress_bar_set_fraction(GTK_PROGRESS_BAR(vol->progress), fraction);
-		snprintf(str_progress, 10, "%.0f%%", fraction * 100.0f);
+		arr_snprintf(str_progress, "%.0f%%", fraction * 100.0f);
 		gtk_progress_bar_set_text(GTK_PROGRESS_BAR(vol->progress), str_progress);
 	}
 

--- a/src/volume.c
+++ b/src/volume.c
@@ -52,12 +52,12 @@ int vol_slot_count;
 
 
 void
-voladj2str(float voladj, char * str) {
+voladj2str(float voladj, char * str, size_t str_size) {
 
 	if (fabs(voladj) < 0.05f) {
-		sprintf(str, " %.1f dB", 0.0f);
+		snprintf(str, str_size, " %.1f dB", 0.0f);
 	} else {
-		sprintf(str, "% .1f dB", voladj);
+		snprintf(str, str_size, "% .1f dB", voladj);
 	}
 }
 
@@ -272,7 +272,7 @@ vol_store_voladj(GtkTreeStore * store, GtkTreeIter * iter, float voladj) {
 	} else { /* playlist */
 		playlist_data_t * data;
 		char str[32];
-		voladj2str(voladj, str);
+		voladj2str(voladj, str, CHAR_ARRAY_SIZE(str));
 		gtk_tree_model_get(GTK_TREE_MODEL(store), iter, PL_COL_DATA, &data, -1);
 		data->voladj = voladj;
 		gtk_tree_store_set(store, iter, PL_COL_VADJ, str, -1);

--- a/src/volume.h
+++ b/src/volume.h
@@ -83,7 +83,7 @@ volume_t * volume_new(GtkTreeStore * store, int type);
 void volume_push(volume_t * vol, char * file, GtkTreeIter iter);
 void volume_start(volume_t * vol);
 
-void voladj2str(float voladj, char * str);
+void voladj2str(float voladj, char * str, size_t str_size);
 
 float rva_from_volume(float volume);
 float rva_from_replaygain(float rg);


### PR DESCRIPTION
This is the other set of changes I had sitting around from a couple of years ago - I've rebased it against the current version and split it up into (hopefully) reviewable chunks, but it's still pretty big, I'm afraid.

The general idea is to modernise Aqualung's string handling, using bounded operations like `g_strlcpy`, `g_strlcat` and `snprintf` instead of `strcat` etc. Since most of Aqualung uses fixed-size arrays for strings, the first commit introduces a handful of macros that let us (safely) avoid writing `sizeof` all over the place, and the majority of the changes were done mechanically, with a few functions needing to be modified to know the size of the strings they're writing to.

Overall the code ends up a bit simpler in most cases, and I've fixed several places where bounds checking was missing or wrong, so it should be a bit more resilient.

The one function I haven't modernised is `file_transform` - because I'm not entirely convinced I understand everything it's doing! It may be easier to rewrite it using `GString` in the future as I've done for `metadata_value_all`.