### PR TITLE
Update README to reflect closure of the aqualung-friends mailing list

### DIFF
--- a/README
+++ b/README
@@ -14,17 +14,9 @@ including compilation instructions.
 Please refer to the documentation provided on the homepage for a
 detailed description of features, usage tips and miscellaneous info.
 
-Please consider subscribing to the project's mailing list at:
-http://lists.sourceforge.net/lists/listinfo/aqualung-friends
+The only supported way of interacting with this project is via GitHub
+issues and pull requests.
 
-General questions about compiling, usage etc. should go to this list
-rather than the developer's private address. This is also the place
-for development discussions.
-
-The primary way for participating in development is sending GitHub
-pull requests.
-
-
-Enjoy,
-
-Tom Szilagyi <tszilagyi@users.sourceforge.net>
+There exists a mailing list that is now closed and mainly of
+historical interest:
+https://sourceforge.net/p/aqualung/mailman/aqualung-friends

--- a/autogen.sh
+++ b/autogen.sh
@@ -28,8 +28,5 @@ You can now run:
     make
     make install
 
-Please take the time to subscribe to the project mailing list at:
-http://lists.sourceforge.net/lists/listinfo/aqualung-friends
-
 "
 fi


### PR DESCRIPTION
I changed the aqualung-friends mailing list on SourceForge (as well as its sibling aqualung-svn) to Closed status, which means the list is no longer open for subscribers. The archives are still preserved and publicly browsable. This PR reflects the change in the README etc.