### PR TITLE
Fix three problems found by AddressSanitizer

### DIFF
--- a/src/file_info.c
+++ b/src/file_info.c
@@ -376,7 +376,6 @@ info_window_close(GtkWidget * widget, GdkEventAny * event, gpointer data) {
 
 	unregister_toplevel_window(fi->info_window);
 	gtk_widget_destroy(fi->info_window);
-	trashlist_free(fi->trash);
 
 	fi_delete(fi);
 	return TRUE;

--- a/src/file_info.c
+++ b/src/file_info.c
@@ -219,6 +219,9 @@ fi_new(void) {
 void
 fi_unload(fi_t * fi) {
 	fi->media_ok = FALSE;
+
+	/* We don't need to destroy these widgets if the window is being
+	   closed; see info_window_close. */
 	if (fi->save_button) {
 		if (GTK_IS_WIDGET(fi->save_button)) gtk_widget_destroy(fi->save_button);
 		fi->save_button = NULL;
@@ -365,6 +368,11 @@ info_window_close(GtkWidget * widget, GdkEventAny * event, gpointer data) {
 	if (fi_can_close(fi) != TRUE) {
 		return TRUE;
 	}
+
+	/* These widgets will be destroyed along with info_window;
+	   stop fi_unload from trying to delete them too. */
+	fi->save_button = NULL;
+	fi->add_tag_table = NULL;
 
 	unregister_toplevel_window(fi->info_window);
 	gtk_widget_destroy(fi->info_window);

--- a/src/transceiver.c
+++ b/src/transceiver.c
@@ -139,7 +139,7 @@ send_message(const char * filename, char * message, int len) {
         arr_strlcpy(name.sun_path, filename);
 
 	do {
-		nbytes = sendto(sock, message, len+1, 0, (struct sockaddr *)&name, sizeof(name));
+		nbytes = sendto(sock, message, len, 0, (struct sockaddr *)&name, sizeof(name));
 		if (nbytes == -1 && errno == ENOBUFS) {
 			g_usleep(100000);
 		}


### PR DESCRIPTION
Aqualung crashed while closing the file info window. Having built the program with AddressSanitizer, this turns out to be a couple of different double-free problems related to `info_window_close`.

ASan also pointed out an out-of-bounds read in the remote control code, so I've fixed that too.

(ASan also reports some memory leaks, which I haven't checked out yet - these may be library-related, though.)