### PR TITLE
Add platform define when enabling mac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -277,7 +277,13 @@ AQUALUNG_DETECT([lavc], [Libav / FFmpeg],
 
 AQUALUNG_DETECT([MAC], [Monkey's Audio Codec],
     [AC_CHECK_LIB([MAC], [CreateIAPEDecompress],
-        [AQUALUNG_FOUND([MAC], [-lMAC -lstdc++])],
+        [
+          AQUALUNG_FOUND([MAC], [-lMAC -lstdc++]),
+          AS_CASE([$host_os],
+            [cygwin*|mingw*], [AC_DEFINE([PLATFORM_WINDOWS], [1], [Defined if Windows])],
+            [darwin*], [AC_DEFINE([PLATFORM_DARWIN], [1], [Defined if Darwin])],
+            [linux*], [AC_DEFINE([PLATFORM_LINUX], [1], [Defined if Linux])])
+        ],
         [AQUALUNG_MISSING([MAC],
             [Monkey's Audio Codec support requires libMAC])],
         [-lstdc++])])


### PR DESCRIPTION
Per the comment on top of `MAC/All.h`, Monkey's Audio requires a define for the platform being built against. Among other things, this fixes the build on Linux when enabling mac, which currently fails with

```
g++ -DHAVE_CONFIG_H -I. -I..  -DAQUALUNG_DATADIR=\"/usr/local/share/aqualung\" -DLOCALEDIR=\"/usr/local/share/locale\" -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/sysprof-4 -pthread         -DAQUALUNG_SKINDIR=\"/usr/local/share/aqualung/skin\"  -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/sysprof-4 -pthread  -Wall -g -O2 -MT decoder/aqualung-dec_mac.o -MD -MP -MF decoder/.deps/aqualung-dec_mac.Tpo -c -o decoder/aqualung-dec_mac.o `test -f 'decoder/dec_mac.cpp' || echo './'`decoder/dec_mac.cpp
In file included from decoder/dec_mac.cpp:31:
/usr/include/MAC/All.h:64:14: fatal error: Windows.h: No such file or directory
   64 |     #include <Windows.h>
      |              ^~~~~~~~~~~
compilation terminated.
```

as MAC mistakenly picks up the platform as Windows when no define is present.