### PR TITLE
Fix typo in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -270,7 +270,7 @@ AQUALUNG_DETECT([lavc], [Libav / FFmpeg],
 AQUALUNG_DETECT([MAC], [Monkey's Audio Codec],
     [AC_CHECK_LIB([MAC], [CreateIAPEDecompress],
         [
-          AQUALUNG_FOUND([MAC], [-lMAC -lstdc++]),
+          AQUALUNG_FOUND([MAC], [-lMAC -lstdc++])
           AS_CASE([$host_os],
             [cygwin*|mingw*], [AC_DEFINE([PLATFORM_WINDOWS], [1], [Defined if Windows])],
             [darwin*], [AC_DEFINE([PLATFORM_DARWIN], [1], [Defined if Darwin])],


### PR DESCRIPTION
The platform defines added  in commit 8e62717 introduced an unnecessary comma which results in a configure warning.