### PR TITLE
Add `opus` extension to file chooser filter for LAVC

### DIFF
--- a/src/utils_gui.c
+++ b/src/utils_gui.c
@@ -501,8 +501,8 @@ assign_audio_fc_filters(GtkFileChooser * fc) {
 		char * valid_ext_lavc[] = {
 			"aac", "ac3", "aiff", "ape", "asf", "au", "avi", "flac", "m4a",
 			"mpa", "mpc", "mpeg", "mpega", "mpg", "mpga", "mp1", "mp2",
-			"mp2a", "mp3", "mpa2", "ogg", "ra", "spx", "voc", "w64", "wav",
-			"wma", "wv", NULL };
+			"mp2a", "mp3", "mpa2", "ogg", "opus", "ra", "spx", "voc", "w64",
+			"wav", "wma", "wv", NULL };
 		build_filter_from_extensions(filter, filter_all, valid_ext_lavc);
 	}
         gtk_file_chooser_add_filter(fc, filter);


### PR DESCRIPTION
Surely there must be a metaprogramming way, to populate the filter with all file extensions supported by the linked ffmpeg library dynamically (look for `.p.extensions` in [`libavformat/oggenc.c`](https://git.ffmpeg.org/gitweb/ffmpeg.git/blob/HEAD:/libavformat/oggenc.c)), but here we only add the very popular `opus` extension manually.

I am closing #45 with this; the ideas are out there, no point in keeping it open:

Closes #45 

As of the time of writing, it can be tested with:
```sh
nix run --override-input nixpkgs nixpkgs github:amiryal/mypkgs#aqualung --
```