### PR TITLE
use avcodec_free_context in place of avcodec_close()

### DIFF
--- a/src/decoder/dec_lavc.c
+++ b/src/decoder/dec_lavc.c
@@ -360,7 +360,7 @@ lavc_decoder_close(decoder_t * dec) {
 
 	lavc_pdata_t * pd = (lavc_pdata_t *)dec->pdata;
 
-	avcodec_close(pd->avCodecCtx);
+	avcodec_free_context(&pd->avCodecCtx);
 
 	avformat_close_input(&pd->avFormatCtx);
 


### PR DESCRIPTION
avcodec_close() has been discouraged since 2016 and deprecated since 7.0:

https://github.com/FFmpeg/FFmpeg/commit/1cc24d749569a42510399a29b034f7a77bdec34e

This fixes building with FFmpeg 8.0, where it was finally dropped.